### PR TITLE
fix dialog positioning in docs

### DIFF
--- a/src/routes/docs/examples/dialog.svelte
+++ b/src/routes/docs/examples/dialog.svelte
@@ -46,10 +46,6 @@
         <DialogOverlay class="fixed inset-0" />
       </TransitionChild>
 
-      <!-- This element is to trick the browser into centering the modal contents. -->
-      <span class="inline-block h-screen align-middle" aria-hidden="true">
-        &#8203;
-      </span>
       <TransitionChild
         enter="ease-out duration-300"
         enterFrom="opacity-0 scale-95"
@@ -58,6 +54,10 @@
         leaveFrom="opacity-100 scale-100"
         leaveTo="opacity-0 scale-95"
       >
+        <!-- This element is to trick the browser into centering the modal contents. -->
+        <span class="inline-block h-screen align-middle" aria-hidden="true">
+          &#8203;
+        </span>
         <div
           class="inline-block w-full max-w-md p-6 my-8 overflow-hidden text-left align-middle transition-all transform bg-white shadow-xl rounded-2xl"
         >


### PR DESCRIPTION
Thank you for this awesome package!


Before:
![before_dialog](https://user-images.githubusercontent.com/33713262/155581180-70b08e33-330e-4184-96ce-632bc53bc224.png)

After:
![after_dialog](https://user-images.githubusercontent.com/33713262/155581190-79ab8380-5762-491d-a52f-2b418f704f5b.png)
