### PR TITLE
Improve TypeScript support + JSDoc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9847,9 +9847,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
+      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -17646,9 +17646,9 @@
       }
     },
     "typescript": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
+      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
       "dev": true
     },
     "unicode-canonical-property-names-ecmascript": {

--- a/src/lib/components/dialog/Dialog.svelte
+++ b/src/lib/components/dialog/Dialog.svelte
@@ -41,7 +41,7 @@
   type TDialogProps<
     TSlotProps extends {},
     TAsProp extends SupportedAs
-  > = TPassThroughProps<TSlotProps, TAsProp> & {
+  > = TPassThroughProps<TSlotProps, TAsProp, "div"> & {
     open?: boolean;
     initialFocus?: HTMLElement | null;
     static?: boolean;

--- a/src/lib/components/dialog/Dialog.svelte
+++ b/src/lib/components/dialog/Dialog.svelte
@@ -42,9 +42,13 @@
     TSlotProps extends {},
     TAsProp extends SupportedAs
   > = TPassThroughProps<TSlotProps, TAsProp, "div"> & {
+    /** Whether the `Dialog` is open */
     open?: boolean;
+    /** The element that should receive focus when the Dialog is first opened */
     initialFocus?: HTMLElement | null;
+    /** Whether the element should ignore the internally managed open/closed state */
     static?: boolean;
+    /** Whether the element should be unmounted, instead of just hidden, based on the open/closed state	*/
     unmount?: boolean;
   };
 </script>

--- a/src/lib/components/dialog/Dialog.svelte
+++ b/src/lib/components/dialog/Dialog.svelte
@@ -37,6 +37,16 @@
     }
     return context;
   }
+
+  type TDialogProps<
+    TSlotProps extends {},
+    TAsProp extends SupportedAs
+  > = TPassThroughProps<TSlotProps, TAsProp> & {
+    open?: boolean;
+    initialFocus?: HTMLElement | null;
+    static?: boolean;
+    unmount?: boolean;
+  };
 </script>
 
 <script lang="ts">
@@ -60,20 +70,29 @@
   import { get_current_component } from "svelte/internal";
   import type { SupportedAs } from "$lib/internal/elements";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
-  import Render, { Features } from "$lib/utils/Render.svelte";
+  import Render, {
+    Features,
+    type TPassThroughProps,
+  } from "$lib/utils/Render.svelte";
+
+  /***** Props *****/
+  type TAsProp = $$Generic<SupportedAs>;
+  type $$Props = TDialogProps<typeof slotProps, TAsProp>;
+
+  export let as: SupportedAs = "div";
+  export let use: HTMLActionArray = [];
+  export let open: boolean | undefined = undefined;
+  export let initialFocus: HTMLElement | null = null;
+
+  /***** Events *****/
   const forwardEvents = forwardEventsBuilder(get_current_component(), [
     "close",
   ]);
-  export let as: SupportedAs = "div";
-  export let use: HTMLActionArray = [];
-
-  export let open: Boolean | undefined = undefined;
-  export let initialFocus: HTMLElement | null = null;
-
   const dispatch = createEventDispatcher<{
     close: boolean;
   }>();
 
+  /***** Component *****/
   let containers: Set<HTMLElement> = new Set();
   let openClosedState = useOpenClosed();
 

--- a/src/lib/components/dialog/Dialog.svelte
+++ b/src/lib/components/dialog/Dialog.svelte
@@ -74,10 +74,8 @@
   import { get_current_component } from "svelte/internal";
   import type { SupportedAs } from "$lib/internal/elements";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
-  import Render, {
-    Features,
-    type TPassThroughProps,
-  } from "$lib/utils/Render.svelte";
+  import Render from "$lib/utils/Render.svelte";
+  import { Features, type TPassThroughProps } from "$lib/types";
 
   /***** Props *****/
   type TAsProp = $$Generic<SupportedAs>;

--- a/src/lib/components/dialog/DialogOverlay.svelte
+++ b/src/lib/components/dialog/DialogOverlay.svelte
@@ -12,7 +12,8 @@
   import { get_current_component } from "svelte/internal";
   import type { SupportedAs } from "$lib/internal/elements";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
-  import Render, { type TPassThroughProps } from "$lib/utils/Render.svelte";
+  import Render from "$lib/utils/Render.svelte";
+  import type { TPassThroughProps } from "$lib/types";
 
   /***** Props *****/
   type TAsProp = $$Generic<SupportedAs>;

--- a/src/lib/components/dialog/DialogOverlay.svelte
+++ b/src/lib/components/dialog/DialogOverlay.svelte
@@ -1,3 +1,10 @@
+<script lang="ts" context="module">
+  type TDialogOverlayProps<
+    TSlotProps extends {},
+    TAsProp extends SupportedAs
+  > = TPassThroughProps<TSlotProps, TAsProp> & {};
+</script>
+
 <script lang="ts">
   import { DialogStates, useDialogContext } from "./Dialog.svelte";
   import { useId } from "$lib/hooks/use-id";
@@ -5,11 +12,19 @@
   import { get_current_component } from "svelte/internal";
   import type { SupportedAs } from "$lib/internal/elements";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
-  import Render from "$lib/utils/Render.svelte";
-  const forwardEvents = forwardEventsBuilder(get_current_component());
+  import Render, { type TPassThroughProps } from "$lib/utils/Render.svelte";
+
+  /***** Props *****/
+  type TAsProp = $$Generic<SupportedAs>;
+  type $$Props = TDialogOverlayProps<typeof slotProps, TAsProp>;
 
   export let as: SupportedAs = "div";
   export let use: HTMLActionArray = [];
+
+  /***** Events *****/
+  const forwardEvents = forwardEventsBuilder(get_current_component());
+
+  /***** Component *****/
 
   let api = useDialogContext("DialogOverlay");
   let id = `headlessui-dialog-overlay-${useId()}`;

--- a/src/lib/components/dialog/DialogOverlay.svelte
+++ b/src/lib/components/dialog/DialogOverlay.svelte
@@ -2,7 +2,7 @@
   type TDialogOverlayProps<
     TSlotProps extends {},
     TAsProp extends SupportedAs
-  > = TPassThroughProps<TSlotProps, TAsProp> & {};
+  > = TPassThroughProps<TSlotProps, TAsProp, "div"> & {};
 </script>
 
 <script lang="ts">

--- a/src/lib/components/dialog/DialogTitle.svelte
+++ b/src/lib/components/dialog/DialogTitle.svelte
@@ -2,7 +2,7 @@
   type TDialogTitleProps<
     TSlotProps extends {},
     TAsProp extends SupportedAs
-  > = TPassThroughProps<TSlotProps, TAsProp> & {};
+  > = TPassThroughProps<TSlotProps, TAsProp, "h2"> & {};
 </script>
 
 <script lang="ts">

--- a/src/lib/components/dialog/DialogTitle.svelte
+++ b/src/lib/components/dialog/DialogTitle.svelte
@@ -1,3 +1,10 @@
+<script lang="ts" context="module">
+  type TDialogTitleProps<
+    TSlotProps extends {},
+    TAsProp extends SupportedAs
+  > = TPassThroughProps<TSlotProps, TAsProp> & {};
+</script>
+
 <script lang="ts">
   import { DialogStates, useDialogContext } from "./Dialog.svelte";
   import { useId } from "$lib/hooks/use-id";
@@ -6,11 +13,19 @@
   import { get_current_component } from "svelte/internal";
   import type { SupportedAs } from "$lib/internal/elements";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
-  import Render from "$lib/utils/Render.svelte";
-  const forwardEvents = forwardEventsBuilder(get_current_component());
+  import Render, { type TPassThroughProps } from "$lib/utils/Render.svelte";
+
+  /***** Props *****/
+  type TAsProp = $$Generic<SupportedAs>;
+  type $$Props = TDialogTitleProps<typeof slotProps, TAsProp>;
+
   export let as: SupportedAs = "h2";
   export let use: HTMLActionArray = [];
 
+  /***** Events *****/
+  const forwardEvents = forwardEventsBuilder(get_current_component());
+
+  /***** Component *****/
   let api = useDialogContext("DialogTitle");
   let id = `headlessui-dialog-title-${useId()}`;
 

--- a/src/lib/components/dialog/DialogTitle.svelte
+++ b/src/lib/components/dialog/DialogTitle.svelte
@@ -13,7 +13,8 @@
   import { get_current_component } from "svelte/internal";
   import type { SupportedAs } from "$lib/internal/elements";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
-  import Render, { type TPassThroughProps } from "$lib/utils/Render.svelte";
+  import Render from "$lib/utils/Render.svelte";
+  import type { TPassThroughProps } from "$lib/types";
 
   /***** Props *****/
   type TAsProp = $$Generic<SupportedAs>;

--- a/src/lib/components/disclosure/Disclosure.svelte
+++ b/src/lib/components/disclosure/Disclosure.svelte
@@ -40,6 +40,13 @@
 
     return context;
   }
+
+  type TDisclosureProps<
+    TSlotProps extends {},
+    TAsProp extends SupportedAs
+  > = TPassThroughProps<TSlotProps, TAsProp> & {
+    defaultOpen?: boolean;
+  };
 </script>
 
 <script lang="ts">
@@ -50,13 +57,20 @@
   import { get_current_component } from "svelte/internal";
   import type { SupportedAs } from "$lib/internal/elements";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
-  import Render from "$lib/utils/Render.svelte";
-  const forwardEvents = forwardEventsBuilder(get_current_component());
+  import Render, { type TPassThroughProps } from "$lib/utils/Render.svelte";
+
+  /***** Props *****/
+  type TAsProp = $$Generic<SupportedAs>;
+  type $$Props = TDisclosureProps<typeof slotProps, TAsProp>;
 
   export let as: SupportedAs = "div";
   export let use: HTMLActionArray = [];
-
   export let defaultOpen = false;
+
+  /***** Events *****/
+  const forwardEvents = forwardEventsBuilder(get_current_component());
+
+  /***** Component *****/
   let buttonId = `headlessui-disclosure-button-${useId()}`;
   let panelId = `headlessui-disclosure-panel-${useId()}`;
 

--- a/src/lib/components/disclosure/Disclosure.svelte
+++ b/src/lib/components/disclosure/Disclosure.svelte
@@ -44,7 +44,7 @@
   type TDisclosureProps<
     TSlotProps extends {},
     TAsProp extends SupportedAs
-  > = TPassThroughProps<TSlotProps, TAsProp> & {
+  > = TPassThroughProps<TSlotProps, TAsProp, "div"> & {
     defaultOpen?: boolean;
   };
 </script>

--- a/src/lib/components/disclosure/Disclosure.svelte
+++ b/src/lib/components/disclosure/Disclosure.svelte
@@ -45,6 +45,7 @@
     TSlotProps extends {},
     TAsProp extends SupportedAs
   > = TPassThroughProps<TSlotProps, TAsProp, "div"> & {
+    /** Whether the `Disclosure` should be open by default */
     defaultOpen?: boolean;
   };
 </script>

--- a/src/lib/components/disclosure/Disclosure.svelte
+++ b/src/lib/components/disclosure/Disclosure.svelte
@@ -58,7 +58,8 @@
   import { get_current_component } from "svelte/internal";
   import type { SupportedAs } from "$lib/internal/elements";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
-  import Render, { type TPassThroughProps } from "$lib/utils/Render.svelte";
+  import Render from "$lib/utils/Render.svelte";
+  import type { TPassThroughProps } from "$lib/types";
 
   /***** Props *****/
   type TAsProp = $$Generic<SupportedAs>;

--- a/src/lib/components/disclosure/DisclosureButton.svelte
+++ b/src/lib/components/disclosure/DisclosureButton.svelte
@@ -15,9 +15,10 @@
   import { get_current_component } from "svelte/internal";
   import type { SupportedAs } from "$lib/internal/elements";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
-  import Render, { type TPassThroughProps } from "$lib/utils/Render.svelte";
+  import Render from "$lib/utils/Render.svelte";
   import { writable } from "svelte/store";
   import { resolveButtonType } from "$lib/utils/resolve-button-type";
+  import type { TPassThroughProps } from "$lib/types";
 
   /***** Props *****/
   type TAsProp = $$Generic<SupportedAs>;

--- a/src/lib/components/disclosure/DisclosureButton.svelte
+++ b/src/lib/components/disclosure/DisclosureButton.svelte
@@ -2,7 +2,7 @@
   type TDisclosureButtonProps<
     TSlotProps extends {},
     TAsProp extends SupportedAs
-  > = TPassThroughProps<TSlotProps, TAsProp> & {
+  > = TPassThroughProps<TSlotProps, TAsProp, "button"> & {
     disabled?: boolean;
   };
 </script>

--- a/src/lib/components/disclosure/DisclosureButton.svelte
+++ b/src/lib/components/disclosure/DisclosureButton.svelte
@@ -1,3 +1,12 @@
+<script lang="ts" context="module">
+  type TDisclosureButtonProps<
+    TSlotProps extends {},
+    TAsProp extends SupportedAs
+  > = TPassThroughProps<TSlotProps, TAsProp> & {
+    disabled?: boolean;
+  };
+</script>
+
 <script lang="ts">
   import { useDisclosureContext, DisclosureStates } from "./Disclosure.svelte";
   import { usePanelContext } from "./DisclosurePanel.svelte";
@@ -6,15 +15,22 @@
   import { get_current_component } from "svelte/internal";
   import type { SupportedAs } from "$lib/internal/elements";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
-  import Render from "$lib/utils/Render.svelte";
+  import Render, { type TPassThroughProps } from "$lib/utils/Render.svelte";
   import { writable } from "svelte/store";
   import { resolveButtonType } from "$lib/utils/resolve-button-type";
-  const forwardEvents = forwardEventsBuilder(get_current_component());
+
+  /***** Props *****/
+  type TAsProp = $$Generic<SupportedAs>;
+  type $$Props = TDisclosureButtonProps<typeof slotProps, TAsProp>;
 
   export let as: SupportedAs = "button";
   export let use: HTMLActionArray = [];
-
   export let disabled = false;
+
+  /***** Events *****/
+  const forwardEvents = forwardEventsBuilder(get_current_component());
+
+  /***** Component *****/
   const api = useDisclosureContext("DisclosureButton");
   const panelContext = usePanelContext();
 

--- a/src/lib/components/disclosure/DisclosurePanel.svelte
+++ b/src/lib/components/disclosure/DisclosurePanel.svelte
@@ -5,6 +5,13 @@
   export function usePanelContext(): string | undefined {
     return getContext(DISCLOSURE_PANEL_CONTEXT_NAME);
   }
+  type TDisclosurePanelProps<
+    TSlotProps extends {},
+    TAsProp extends SupportedAs
+  > = TPassThroughProps<TSlotProps, TAsProp> & {
+    unmount?: boolean;
+    static?: boolean;
+  };
 </script>
 
 <script lang="ts">
@@ -14,12 +21,22 @@
   import { get_current_component } from "svelte/internal";
   import type { SupportedAs } from "$lib/internal/elements";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
-  import Render, { Features } from "$lib/utils/Render.svelte";
-  const forwardEvents = forwardEventsBuilder(get_current_component());
+  import Render, {
+    Features,
+    type TPassThroughProps,
+  } from "$lib/utils/Render.svelte";
+
+  /***** Props *****/
+  type TAsProp = $$Generic<SupportedAs>;
+  type $$Props = TDisclosurePanelProps<typeof slotProps, TAsProp>;
 
   export let as: SupportedAs = "div";
   export let use: HTMLActionArray = [];
 
+  /***** Events *****/
+  const forwardEvents = forwardEventsBuilder(get_current_component());
+
+  /***** Component *****/
   const api = useDisclosureContext("DisclosurePanel");
   let openClosedState = useOpenClosed();
 

--- a/src/lib/components/disclosure/DisclosurePanel.svelte
+++ b/src/lib/components/disclosure/DisclosurePanel.svelte
@@ -23,10 +23,8 @@
   import { get_current_component } from "svelte/internal";
   import type { SupportedAs } from "$lib/internal/elements";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
-  import Render, {
-    Features,
-    type TPassThroughProps,
-  } from "$lib/utils/Render.svelte";
+  import Render from "$lib/utils/Render.svelte";
+  import { Features, type TPassThroughProps } from "$lib/types";
 
   /***** Props *****/
   type TAsProp = $$Generic<SupportedAs>;

--- a/src/lib/components/disclosure/DisclosurePanel.svelte
+++ b/src/lib/components/disclosure/DisclosurePanel.svelte
@@ -8,7 +8,7 @@
   type TDisclosurePanelProps<
     TSlotProps extends {},
     TAsProp extends SupportedAs
-  > = TPassThroughProps<TSlotProps, TAsProp> & {
+  > = TPassThroughProps<TSlotProps, TAsProp, "div"> & {
     unmount?: boolean;
     static?: boolean;
   };

--- a/src/lib/components/disclosure/DisclosurePanel.svelte
+++ b/src/lib/components/disclosure/DisclosurePanel.svelte
@@ -9,8 +9,10 @@
     TSlotProps extends {},
     TAsProp extends SupportedAs
   > = TPassThroughProps<TSlotProps, TAsProp, "div"> & {
-    unmount?: boolean;
+    /** Whether the element should ignore the internally managed open/closed state */
     static?: boolean;
+    /** Whether the element should be unmounted, instead of just hidden, based on the open/closed state	*/
+    unmount?: boolean;
   };
 </script>
 

--- a/src/lib/components/listbox/Listbox.svelte
+++ b/src/lib/components/listbox/Listbox.svelte
@@ -53,7 +53,7 @@
   type TListboxProps<
     TSlotProps extends {},
     TAsProp extends SupportedAs
-  > = TPassThroughProps<TSlotProps, TAsProp> & {
+  > = TPassThroughProps<TSlotProps, TAsProp, "div"> & {
     disabled?: boolean;
     horizontal?: boolean;
     value?: StateDefinition["value"];

--- a/src/lib/components/listbox/Listbox.svelte
+++ b/src/lib/components/listbox/Listbox.svelte
@@ -50,12 +50,16 @@
 
     return context;
   }
+
   type TListboxProps<
     TSlotProps extends {},
     TAsProp extends SupportedAs
   > = TPassThroughProps<TSlotProps, TAsProp, "div"> & {
+    /** Whether the entire `Listbox` and its children should be disabled */
     disabled?: boolean;
+    /** Whether the entire `Listbox` should be oriented horizontally instead of vertically */
     horizontal?: boolean;
+    /** The selected value */
     value?: StateDefinition["value"];
   };
 </script>

--- a/src/lib/components/listbox/Listbox.svelte
+++ b/src/lib/components/listbox/Listbox.svelte
@@ -78,7 +78,8 @@
   import { get_current_component } from "svelte/internal";
   import type { SupportedAs } from "$lib/internal/elements";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
-  import Render, { type TPassThroughProps } from "$lib/utils/Render.svelte";
+  import Render from "$lib/utils/Render.svelte";
+  import type { TPassThroughProps } from "$lib/types";
 
   /***** Props *****/
   type TAsProp = $$Generic<SupportedAs>;

--- a/src/lib/components/listbox/Listbox.svelte
+++ b/src/lib/components/listbox/Listbox.svelte
@@ -50,6 +50,14 @@
 
     return context;
   }
+  type TListboxProps<
+    TSlotProps extends {},
+    TAsProp extends SupportedAs
+  > = TPassThroughProps<TSlotProps, TAsProp> & {
+    disabled?: boolean;
+    horizontal?: boolean;
+    value?: StateDefinition["value"];
+  };
 </script>
 
 <script lang="ts">
@@ -66,23 +74,31 @@
   import { get_current_component } from "svelte/internal";
   import type { SupportedAs } from "$lib/internal/elements";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
-  import Render from "$lib/utils/Render.svelte";
-  const forwardEvents = forwardEventsBuilder(get_current_component(), [
-    "change",
-  ]);
+  import Render, { type TPassThroughProps } from "$lib/utils/Render.svelte";
+
+  /***** Props *****/
+  type TAsProp = $$Generic<SupportedAs>;
+  type $$Props = TListboxProps<typeof slotProps, TAsProp>;
+
   export let as: SupportedAs = "div";
   export let use: HTMLActionArray = [];
-
   export let disabled = false;
   export let horizontal = false;
   export let value: StateDefinition["value"];
-  $: orientation = (
-    horizontal ? "horizontal" : "vertical"
-  ) as StateDefinition["orientation"];
+
+  /***** Events *****/
+  const forwardEvents = forwardEventsBuilder(get_current_component(), [
+    "change",
+  ]);
 
   const dispatch = createEventDispatcher<{
     change: any;
   }>();
+
+  /***** Component *****/
+  $: orientation = (
+    horizontal ? "horizontal" : "vertical"
+  ) as StateDefinition["orientation"];
 
   let listboxState: StateDefinition["listboxState"] = ListboxStates.Closed;
   let labelRef: StateDefinition["labelRef"] = writable(null);

--- a/src/lib/components/listbox/ListboxButton.svelte
+++ b/src/lib/components/listbox/ListboxButton.svelte
@@ -2,7 +2,7 @@
   type TListboxButtonProps<
     TSlotProps extends {},
     TAsProp extends SupportedAs
-  > = TPassThroughProps<TSlotProps, TAsProp> & {};
+  > = TPassThroughProps<TSlotProps, TAsProp, "button"> & {};
 </script>
 
 <script lang="ts">

--- a/src/lib/components/listbox/ListboxButton.svelte
+++ b/src/lib/components/listbox/ListboxButton.svelte
@@ -15,8 +15,9 @@
   import type { SupportedAs } from "$lib/internal/elements";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
   import { get_current_component } from "svelte/internal";
-  import Render, { type TPassThroughProps } from "$lib/utils/Render.svelte";
+  import Render from "$lib/utils/Render.svelte";
   import { resolveButtonType } from "$lib/utils/resolve-button-type";
+  import type { TPassThroughProps } from "$lib/types";
 
   /***** Props *****/
   type TAsProp = $$Generic<SupportedAs>;

--- a/src/lib/components/listbox/ListboxButton.svelte
+++ b/src/lib/components/listbox/ListboxButton.svelte
@@ -1,3 +1,10 @@
+<script lang="ts" context="module">
+  type TListboxButtonProps<
+    TSlotProps extends {},
+    TAsProp extends SupportedAs
+  > = TPassThroughProps<TSlotProps, TAsProp> & {};
+</script>
+
 <script lang="ts">
   import { tick } from "svelte";
   import { ListboxStates, useListboxContext } from "./Listbox.svelte";
@@ -8,13 +15,20 @@
   import type { SupportedAs } from "$lib/internal/elements";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
   import { get_current_component } from "svelte/internal";
-  import Render from "$lib/utils/Render.svelte";
+  import Render, { type TPassThroughProps } from "$lib/utils/Render.svelte";
   import { resolveButtonType } from "$lib/utils/resolve-button-type";
 
-  const forwardEvents = forwardEventsBuilder(get_current_component());
+  /***** Props *****/
+  type TAsProp = $$Generic<SupportedAs>;
+  type $$Props = TListboxButtonProps<typeof slotProps, TAsProp>;
+
   export let as: SupportedAs = "button";
   export let use: HTMLActionArray = [];
 
+  /***** Events *****/
+  const forwardEvents = forwardEventsBuilder(get_current_component());
+
+  /***** Component *****/
   let api = useListboxContext("ListboxButton");
   let id = `headlessui-listbox-button-${useId()}`;
   let buttonRef = $api.buttonRef;

--- a/src/lib/components/listbox/ListboxLabel.svelte
+++ b/src/lib/components/listbox/ListboxLabel.svelte
@@ -1,16 +1,30 @@
+<script lang="ts" context="module">
+  type TListboxLabelProps<
+    TSlotProps extends {},
+    TAsProp extends SupportedAs
+  > = TPassThroughProps<TSlotProps, TAsProp> & {};
+</script>
+
 <script lang="ts">
   import { ListboxStates, useListboxContext } from "./Listbox.svelte";
   import { useId } from "$lib/hooks/use-id";
-  import Render from "$lib/utils/Render.svelte";
+  import Render, { type TPassThroughProps } from "$lib/utils/Render.svelte";
   import { forwardEventsBuilder } from "$lib/internal/forwardEventsBuilder";
   import type { SupportedAs } from "$lib/internal/elements";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
   import { get_current_component } from "svelte/internal";
 
-  const forwardEvents = forwardEventsBuilder(get_current_component());
+  /***** Props *****/
+  type TAsProp = $$Generic<SupportedAs>;
+  type $$Props = TListboxLabelProps<typeof slotProps, TAsProp>;
+
   export let as: SupportedAs = "label";
   export let use: HTMLActionArray = [];
 
+  /***** Events *****/
+  const forwardEvents = forwardEventsBuilder(get_current_component());
+
+  /***** Component *****/
   let id = `headlessui-listbox-label-${useId()}`;
   let api = useListboxContext("ListboxLabel");
 

--- a/src/lib/components/listbox/ListboxLabel.svelte
+++ b/src/lib/components/listbox/ListboxLabel.svelte
@@ -2,7 +2,7 @@
   type TListboxLabelProps<
     TSlotProps extends {},
     TAsProp extends SupportedAs
-  > = TPassThroughProps<TSlotProps, TAsProp> & {};
+  > = TPassThroughProps<TSlotProps, TAsProp, "label"> & {};
 </script>
 
 <script lang="ts">

--- a/src/lib/components/listbox/ListboxLabel.svelte
+++ b/src/lib/components/listbox/ListboxLabel.svelte
@@ -8,11 +8,12 @@
 <script lang="ts">
   import { ListboxStates, useListboxContext } from "./Listbox.svelte";
   import { useId } from "$lib/hooks/use-id";
-  import Render, { type TPassThroughProps } from "$lib/utils/Render.svelte";
+  import Render from "$lib/utils/Render.svelte";
   import { forwardEventsBuilder } from "$lib/internal/forwardEventsBuilder";
   import type { SupportedAs } from "$lib/internal/elements";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
   import { get_current_component } from "svelte/internal";
+  import type { TPassThroughProps } from "$lib/types";
 
   /***** Props *****/
   type TAsProp = $$Generic<SupportedAs>;

--- a/src/lib/components/listbox/ListboxOption.svelte
+++ b/src/lib/components/listbox/ListboxOption.svelte
@@ -2,7 +2,7 @@
   type TListboxOptionProps<
     TSlotProps extends {},
     TAsProp extends SupportedAs
-  > = TPassThroughProps<TSlotProps, TAsProp> & {
+  > = TPassThroughProps<TSlotProps, TAsProp, "li"> & {
     value: unknown;
     disabled?: boolean;
   };

--- a/src/lib/components/listbox/ListboxOption.svelte
+++ b/src/lib/components/listbox/ListboxOption.svelte
@@ -3,7 +3,9 @@
     TSlotProps extends {},
     TAsProp extends SupportedAs
   > = TPassThroughProps<TSlotProps, TAsProp, "li"> & {
+    /** The option value */
     value: unknown;
+    /** Whether the option should be disabled for keyboard navigation and ARIA purposes */
     disabled?: boolean;
   };
 </script>

--- a/src/lib/components/listbox/ListboxOption.svelte
+++ b/src/lib/components/listbox/ListboxOption.svelte
@@ -15,11 +15,12 @@
   import { ListboxStates, useListboxContext } from "./Listbox.svelte";
   import { useId } from "$lib/hooks/use-id";
   import { Focus } from "$lib/utils/calculate-active-index";
-  import Render, { type TPassThroughProps } from "$lib/utils/Render.svelte";
+  import Render from "$lib/utils/Render.svelte";
   import { forwardEventsBuilder } from "$lib/internal/forwardEventsBuilder";
   import type { SupportedAs } from "$lib/internal/elements";
   import { get_current_component } from "svelte/internal";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
+  import type { TPassThroughProps } from "$lib/types";
 
   /***** Props *****/
   type TAsProp = $$Generic<SupportedAs>;

--- a/src/lib/components/listbox/ListboxOption.svelte
+++ b/src/lib/components/listbox/ListboxOption.svelte
@@ -1,20 +1,37 @@
+<script lang="ts" context="module">
+  type TListboxOptionProps<
+    TSlotProps extends {},
+    TAsProp extends SupportedAs
+  > = TPassThroughProps<TSlotProps, TAsProp> & {
+    value: unknown;
+    disabled?: boolean;
+  };
+</script>
+
 <script lang="ts">
   import { onDestroy, onMount, tick } from "svelte";
   import { ListboxStates, useListboxContext } from "./Listbox.svelte";
   import { useId } from "$lib/hooks/use-id";
   import { Focus } from "$lib/utils/calculate-active-index";
-  import Render from "$lib/utils/Render.svelte";
+  import Render, { type TPassThroughProps } from "$lib/utils/Render.svelte";
   import { forwardEventsBuilder } from "$lib/internal/forwardEventsBuilder";
   import type { SupportedAs } from "$lib/internal/elements";
   import { get_current_component } from "svelte/internal";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
 
-  const forwardEvents = forwardEventsBuilder(get_current_component());
+  /***** Props *****/
+  type TAsProp = $$Generic<SupportedAs>;
+  type $$Props = TListboxOptionProps<typeof slotProps, TAsProp>;
+
   export let as: SupportedAs = "li";
   export let use: HTMLActionArray = [];
-
   export let value: unknown;
   export let disabled = false;
+
+  /***** Events *****/
+  const forwardEvents = forwardEventsBuilder(get_current_component());
+
+  /***** Component *****/
   let api = useListboxContext("ListboxOption");
   let id = `headlessui-listbox-option-${useId()}`;
 

--- a/src/lib/components/listbox/ListboxOptions.svelte
+++ b/src/lib/components/listbox/ListboxOptions.svelte
@@ -2,7 +2,7 @@
   type TListboxOptionsProps<
     TSlotProps extends {},
     TAsProp extends SupportedAs
-  > = TPassThroughProps<TSlotProps, TAsProp> & {
+  > = TPassThroughProps<TSlotProps, TAsProp, "ul"> & {
     unmount?: boolean;
     static?: boolean;
   };

--- a/src/lib/components/listbox/ListboxOptions.svelte
+++ b/src/lib/components/listbox/ListboxOptions.svelte
@@ -1,3 +1,13 @@
+<script lang="ts" context="module">
+  type TListboxOptionsProps<
+    TSlotProps extends {},
+    TAsProp extends SupportedAs
+  > = TPassThroughProps<TSlotProps, TAsProp> & {
+    unmount?: boolean;
+    static?: boolean;
+  };
+</script>
+
 <script lang="ts">
   import { tick } from "svelte";
   import { ListboxStates, useListboxContext } from "./Listbox.svelte";
@@ -6,16 +16,26 @@
   import { Keys } from "$lib/utils/keyboard";
   import { Focus } from "$lib/utils/calculate-active-index";
   import { State, useOpenClosed } from "$lib/internal/open-closed";
-  import Render, { Features } from "$lib/utils/Render.svelte";
+  import Render, {
+    Features,
+    type TPassThroughProps,
+  } from "$lib/utils/Render.svelte";
   import { forwardEventsBuilder } from "$lib/internal/forwardEventsBuilder";
   import type { SupportedAs } from "$lib/internal/elements";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
   import { get_current_component } from "svelte/internal";
 
-  const forwardEvents = forwardEventsBuilder(get_current_component());
+  /***** Props *****/
+  type TAsProp = $$Generic<SupportedAs>;
+  type $$Props = TListboxOptionsProps<typeof slotProps, TAsProp>;
+
   export let as: SupportedAs = "ul";
   export let use: HTMLActionArray = [];
 
+  /***** Events *****/
+  const forwardEvents = forwardEventsBuilder(get_current_component());
+
+  /***** Component *****/
   let api = useListboxContext("ListboxOptions");
   let id = `headlessui-listbox-options-${useId()}`;
   let optionsRef = $api.optionsRef;

--- a/src/lib/components/listbox/ListboxOptions.svelte
+++ b/src/lib/components/listbox/ListboxOptions.svelte
@@ -18,14 +18,12 @@
   import { Keys } from "$lib/utils/keyboard";
   import { Focus } from "$lib/utils/calculate-active-index";
   import { State, useOpenClosed } from "$lib/internal/open-closed";
-  import Render, {
-    Features,
-    type TPassThroughProps,
-  } from "$lib/utils/Render.svelte";
+  import Render from "$lib/utils/Render.svelte";
   import { forwardEventsBuilder } from "$lib/internal/forwardEventsBuilder";
   import type { SupportedAs } from "$lib/internal/elements";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
   import { get_current_component } from "svelte/internal";
+  import { Features, type TPassThroughProps } from "$lib/types";
 
   /***** Props *****/
   type TAsProp = $$Generic<SupportedAs>;

--- a/src/lib/components/listbox/ListboxOptions.svelte
+++ b/src/lib/components/listbox/ListboxOptions.svelte
@@ -3,8 +3,10 @@
     TSlotProps extends {},
     TAsProp extends SupportedAs
   > = TPassThroughProps<TSlotProps, TAsProp, "ul"> & {
-    unmount?: boolean;
+    /** Whether the element should ignore the internally managed open/closed state */
     static?: boolean;
+    /** Whether the element should be unmounted, instead of just hidden, based on the open/closed state	*/
+    unmount?: boolean;
   };
 </script>
 

--- a/src/lib/components/menu/Menu.svelte
+++ b/src/lib/components/menu/Menu.svelte
@@ -57,7 +57,7 @@
   type TMenuProps<
     TSlotProps extends {},
     TAsProp extends SupportedAs
-  > = TPassThroughProps<TSlotProps, TAsProp> & {};
+  > = TPassThroughProps<TSlotProps, TAsProp, "div"> & {};
 </script>
 
 <script lang="ts">

--- a/src/lib/components/menu/Menu.svelte
+++ b/src/lib/components/menu/Menu.svelte
@@ -12,7 +12,8 @@
   import type { SupportedAs } from "$lib/internal/elements";
   import { forwardEventsBuilder } from "$lib/internal/forwardEventsBuilder";
   import { get_current_component } from "svelte/internal";
-  import Render, { type TPassThroughProps } from "$lib/utils/Render.svelte";
+  import Render from "$lib/utils/Render.svelte";
+  import type { TPassThroughProps } from "$lib/types";
 
   export enum MenuStates {
     Open,

--- a/src/lib/components/menu/Menu.svelte
+++ b/src/lib/components/menu/Menu.svelte
@@ -12,7 +12,7 @@
   import type { SupportedAs } from "$lib/internal/elements";
   import { forwardEventsBuilder } from "$lib/internal/forwardEventsBuilder";
   import { get_current_component } from "svelte/internal";
-  import Render from "$lib/utils/Render.svelte";
+  import Render, { type TPassThroughProps } from "$lib/utils/Render.svelte";
 
   export enum MenuStates {
     Open,
@@ -53,13 +53,25 @@
     }
     return context;
   }
+
+  type TMenuProps<
+    TSlotProps extends {},
+    TAsProp extends SupportedAs
+  > = TPassThroughProps<TSlotProps, TAsProp> & {};
 </script>
 
 <script lang="ts">
+  /***** Props *****/
+  type TAsProp = $$Generic<SupportedAs>;
+  type $$Props = TMenuProps<typeof slotProps, TAsProp>;
+
   export let use: HTMLActionArray = [];
   export let as: SupportedAs = "div";
+
+  /***** Events *****/
   const forwardEvents = forwardEventsBuilder(get_current_component());
 
+  /***** Component *****/
   let menuState: StateDefinition["menuState"] = MenuStates.Closed;
   let buttonStore: StateDefinition["buttonStore"] = writable(null);
   let itemsStore: StateDefinition["itemsStore"] = writable(null);

--- a/src/lib/components/menu/MenuButton.svelte
+++ b/src/lib/components/menu/MenuButton.svelte
@@ -2,7 +2,7 @@
   type TMenuButtonProps<
     TSlotProps extends {},
     TAsProp extends SupportedAs
-  > = TPassThroughProps<TSlotProps, TAsProp> & {
+  > = TPassThroughProps<TSlotProps, TAsProp, "button"> & {
     disabled?: boolean;
   };
 </script>

--- a/src/lib/components/menu/MenuButton.svelte
+++ b/src/lib/components/menu/MenuButton.svelte
@@ -1,3 +1,12 @@
+<script lang="ts" context="module">
+  type TMenuButtonProps<
+    TSlotProps extends {},
+    TAsProp extends SupportedAs
+  > = TPassThroughProps<TSlotProps, TAsProp> & {
+    disabled?: boolean;
+  };
+</script>
+
 <script lang="ts">
   import { useMenuContext, MenuStates } from "./Menu.svelte";
   import { useId } from "$lib/hooks/use-id";
@@ -5,16 +14,24 @@
   import { Focus } from "$lib/utils/calculate-active-index";
   import { tick } from "svelte";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
-  import Render from "$lib/utils/Render.svelte";
+  import Render, { type TPassThroughProps } from "$lib/utils/Render.svelte";
   import type { SupportedAs } from "$lib/internal/elements";
   import { forwardEventsBuilder } from "$lib/internal/forwardEventsBuilder";
   import { get_current_component } from "svelte/internal";
   import { resolveButtonType } from "$lib/utils/resolve-button-type";
-  const forwardEvents = forwardEventsBuilder(get_current_component());
+
+  /***** Props *****/
+  type TAsProp = $$Generic<SupportedAs>;
+  type $$Props = TMenuButtonProps<typeof slotProps, TAsProp>;
+
   export let as: SupportedAs = "button";
   export let use: HTMLActionArray = [];
-
   export let disabled = false;
+
+  /***** Events *****/
+  const forwardEvents = forwardEventsBuilder(get_current_component());
+
+  /***** Component *****/
   const api = useMenuContext("MenuButton");
   const id = `headlessui-menu-button-${useId()}`;
 
@@ -84,7 +101,9 @@
     "aria-expanded": disabled ? undefined : $api.menuState === MenuStates.Open,
   };
 
-  $: slotProps = { open: $api.menuState === MenuStates.Open };
+  $: slotProps = {
+    open: $api.menuState === MenuStates.Open,
+  };
 </script>
 
 <Render

--- a/src/lib/components/menu/MenuButton.svelte
+++ b/src/lib/components/menu/MenuButton.svelte
@@ -14,11 +14,12 @@
   import { Focus } from "$lib/utils/calculate-active-index";
   import { tick } from "svelte";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
-  import Render, { type TPassThroughProps } from "$lib/utils/Render.svelte";
+  import Render from "$lib/utils/Render.svelte";
   import type { SupportedAs } from "$lib/internal/elements";
   import { forwardEventsBuilder } from "$lib/internal/forwardEventsBuilder";
   import { get_current_component } from "svelte/internal";
   import { resolveButtonType } from "$lib/utils/resolve-button-type";
+  import type { TPassThroughProps } from "$lib/types";
 
   /***** Props *****/
   type TAsProp = $$Generic<SupportedAs>;

--- a/src/lib/components/menu/MenuItem.svelte
+++ b/src/lib/components/menu/MenuItem.svelte
@@ -14,11 +14,12 @@
   import { useId } from "$lib/hooks/use-id";
   import { Focus } from "$lib/utils/calculate-active-index";
   import { afterUpdate, onDestroy, onMount, tick } from "svelte";
-  import Render, { type TPassThroughProps } from "$lib/utils/Render.svelte";
+  import Render from "$lib/utils/Render.svelte";
   import type { SupportedAs } from "$lib/internal/elements";
   import { forwardEventsBuilder } from "$lib/internal/forwardEventsBuilder";
   import { get_current_component } from "svelte/internal";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
+  import type { TPassThroughProps } from "$lib/types";
 
   /***** Props *****/
   type TAsProp = $$Generic<SupportedAs>;

--- a/src/lib/components/menu/MenuItem.svelte
+++ b/src/lib/components/menu/MenuItem.svelte
@@ -2,7 +2,7 @@
   type TMenuItemProps<
     TSlotProps extends {},
     TAsProp extends SupportedAs
-  > = TPassThroughProps<TSlotProps, TAsProp> & {};
+  > = TPassThroughProps<TSlotProps, TAsProp, "a"> & {};
 </script>
 
 <script lang="ts">

--- a/src/lib/components/menu/MenuItem.svelte
+++ b/src/lib/components/menu/MenuItem.svelte
@@ -1,20 +1,36 @@
+<script lang="ts" context="module">
+  type TMenuItemProps<
+    TSlotProps extends {},
+    TAsProp extends SupportedAs
+  > = TPassThroughProps<TSlotProps, TAsProp> & {};
+</script>
+
 <script lang="ts">
   import type { MenuItemData } from "./Menu.svelte";
   import { useMenuContext, MenuStates } from "./Menu.svelte";
   import { useId } from "$lib/hooks/use-id";
   import { Focus } from "$lib/utils/calculate-active-index";
   import { afterUpdate, onDestroy, onMount, tick } from "svelte";
-  import Render from "$lib/utils/Render.svelte";
+  import Render, { type TPassThroughProps } from "$lib/utils/Render.svelte";
   import type { SupportedAs } from "$lib/internal/elements";
   import { forwardEventsBuilder } from "$lib/internal/forwardEventsBuilder";
   import { get_current_component } from "svelte/internal";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
-  const forwardEvents = forwardEventsBuilder(get_current_component(), [
-    { name: "click", shouldExclude: () => disabled },
-  ]);
+
+  /***** Props *****/
+  type TAsProp = $$Generic<SupportedAs>;
+  type $$Props = TMenuItemProps<typeof slotProps, TAsProp>;
+
   export let as: SupportedAs = "a";
   export let use: HTMLActionArray = [];
   export let disabled = false;
+
+  /***** Events *****/
+  const forwardEvents = forwardEventsBuilder(get_current_component(), [
+    { name: "click", shouldExclude: () => disabled },
+  ]);
+
+  /***** Component *****/
   const api = useMenuContext("MenuItem");
   const id = `headlessui-menu-item-${useId()}`;
 

--- a/src/lib/components/menu/MenuItem.svelte
+++ b/src/lib/components/menu/MenuItem.svelte
@@ -2,7 +2,10 @@
   type TMenuItemProps<
     TSlotProps extends {},
     TAsProp extends SupportedAs
-  > = TPassThroughProps<TSlotProps, TAsProp, "a"> & {};
+  > = TPassThroughProps<TSlotProps, TAsProp, "a"> & {
+    /** Whether the item should be disabled for keyboard navigation and ARIA purposes */
+    disabled?: boolean;
+  };
 </script>
 
 <script lang="ts">

--- a/src/lib/components/menu/MenuItems.svelte
+++ b/src/lib/components/menu/MenuItems.svelte
@@ -20,12 +20,10 @@
   import { tick } from "svelte";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
   import type { SupportedAs } from "$lib/internal/elements";
-  import Render, {
-    Features,
-    type TPassThroughProps,
-  } from "$lib/utils/Render.svelte";
+  import Render from "$lib/utils/Render.svelte";
   import { forwardEventsBuilder } from "$lib/internal/forwardEventsBuilder";
   import { get_current_component } from "svelte/internal";
+  import { Features, type TPassThroughProps } from "$lib/types";
 
   /***** Props *****/
   type TAsProp = $$Generic<SupportedAs>;

--- a/src/lib/components/menu/MenuItems.svelte
+++ b/src/lib/components/menu/MenuItems.svelte
@@ -1,3 +1,13 @@
+<script lang="ts" context="module">
+  type TMenuItemsProps<
+    TSlotProp extends {},
+    TAsProp extends SupportedAs
+  > = TPassThroughProps<TSlotProp, TAsProp> & {
+    static?: boolean;
+    unmount?: boolean;
+  };
+</script>
+
 <script lang="ts">
   import { useMenuContext, MenuStates } from "./Menu.svelte";
   import { useId } from "$lib/hooks/use-id";
@@ -8,13 +18,24 @@
   import { tick } from "svelte";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
   import type { SupportedAs } from "$lib/internal/elements";
-  import Render, { Features } from "$lib/utils/Render.svelte";
+  import Render, {
+    Features,
+    type TPassThroughProps,
+  } from "$lib/utils/Render.svelte";
   import { forwardEventsBuilder } from "$lib/internal/forwardEventsBuilder";
   import { get_current_component } from "svelte/internal";
 
-  const forwardEvents = forwardEventsBuilder(get_current_component());
+  /***** Props *****/
+  type TAsProp = $$Generic<SupportedAs>;
+  type $$Props = TMenuItemsProps<typeof slotProps, TAsProp>;
+
   export let as: SupportedAs = "div";
   export let use: HTMLActionArray = [];
+
+  /***** Events *****/
+  const forwardEvents = forwardEventsBuilder(get_current_component());
+
+  /***** Component *****/
   const api = useMenuContext("MenuItems");
   const id = `headlessui-menu-items-${useId()}`;
   let searchDebounce: ReturnType<typeof setTimeout> | null = null;
@@ -135,7 +156,9 @@
     role: "menu",
     tabIndex: 0,
   };
-  $: slotProps = { open: $api.menuState === MenuStates.Open };
+  $: slotProps = {
+    open: $api.menuState === MenuStates.Open,
+  };
 </script>
 
 <Render

--- a/src/lib/components/menu/MenuItems.svelte
+++ b/src/lib/components/menu/MenuItems.svelte
@@ -3,7 +3,9 @@
     TSlotProp extends {},
     TAsProp extends SupportedAs
   > = TPassThroughProps<TSlotProp, TAsProp, "div"> & {
+    /** Whether the element should ignore the internally managed open/closed state */
     static?: boolean;
+    /** Whether the element should be unmounted, instead of just hidden, based on the open/closed state	*/
     unmount?: boolean;
   };
 </script>

--- a/src/lib/components/menu/MenuItems.svelte
+++ b/src/lib/components/menu/MenuItems.svelte
@@ -2,7 +2,7 @@
   type TMenuItemsProps<
     TSlotProp extends {},
     TAsProp extends SupportedAs
-  > = TPassThroughProps<TSlotProp, TAsProp> & {
+  > = TPassThroughProps<TSlotProp, TAsProp, "div"> & {
     static?: boolean;
     unmount?: boolean;
   };

--- a/src/lib/components/popover/Popover.svelte
+++ b/src/lib/components/popover/Popover.svelte
@@ -61,7 +61,8 @@
   import { get_current_component } from "svelte/internal";
   import type { SupportedAs } from "$lib/internal/elements";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
-  import Render, { type TPassThroughProps } from "$lib/utils/Render.svelte";
+  import Render from "$lib/utils/Render.svelte";
+  import type { TPassThroughProps } from "$lib/types";
 
   /***** Props *****/
   type TAsProp = $$Generic<SupportedAs>;

--- a/src/lib/components/popover/Popover.svelte
+++ b/src/lib/components/popover/Popover.svelte
@@ -42,7 +42,7 @@
   type TPopoverProps<
     TSlotProps extends {},
     TAsProp extends SupportedAs
-  > = TPassThroughProps<TSlotProps, TAsProp> & {};
+  > = TPassThroughProps<TSlotProps, TAsProp, "div"> & {};
 </script>
 
 <script lang="ts">

--- a/src/lib/components/popover/Popover.svelte
+++ b/src/lib/components/popover/Popover.svelte
@@ -39,6 +39,10 @@
     }
     return context;
   }
+  type TPopoverProps<
+    TSlotProps extends {},
+    TAsProp extends SupportedAs
+  > = TPassThroughProps<TSlotProps, TAsProp> & {};
 </script>
 
 <script lang="ts">
@@ -57,12 +61,19 @@
   import { get_current_component } from "svelte/internal";
   import type { SupportedAs } from "$lib/internal/elements";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
-  import Render from "$lib/utils/Render.svelte";
-  const forwardEvents = forwardEventsBuilder(get_current_component());
+  import Render, { type TPassThroughProps } from "$lib/utils/Render.svelte";
+
+  /***** Props *****/
+  type TAsProp = $$Generic<SupportedAs>;
+  type $$Props = TPopoverProps<typeof slotProps, TAsProp>;
 
   export let as: SupportedAs = "div";
   export let use: HTMLActionArray = [];
 
+  /***** Events *****/
+  const forwardEvents = forwardEventsBuilder(get_current_component());
+
+  /***** Component *****/
   const buttonId = `headlessui-popover-button-${useId()}`;
   const panelId = `headlessui-popover-panel-${useId()}`;
   let popoverState: StateDefinition["popoverState"] = PopoverStates.Closed;

--- a/src/lib/components/popover/PopoverButton.svelte
+++ b/src/lib/components/popover/PopoverButton.svelte
@@ -2,7 +2,7 @@
   type TPopoverButtonProps<
     TSlotProps extends {},
     TAsProp extends SupportedAs
-  > = TPassThroughProps<TSlotProps, TAsProp> & {
+  > = TPassThroughProps<TSlotProps, TAsProp, "button"> & {
     disabled?: boolean;
   };
 </script>

--- a/src/lib/components/popover/PopoverButton.svelte
+++ b/src/lib/components/popover/PopoverButton.svelte
@@ -22,8 +22,9 @@
   import { get_current_component } from "svelte/internal";
   import type { SupportedAs } from "$lib/internal/elements";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
-  import Render, { type TPassThroughProps } from "$lib/utils/Render.svelte";
+  import Render from "$lib/utils/Render.svelte";
   import { resolveButtonType } from "$lib/utils/resolve-button-type";
+  import type { TPassThroughProps } from "$lib/types";
 
   /***** Props *****/
   type TAsProp = $$Generic<SupportedAs>;

--- a/src/lib/components/popover/PopoverButton.svelte
+++ b/src/lib/components/popover/PopoverButton.svelte
@@ -1,3 +1,12 @@
+<script lang="ts" context="module">
+  type TPopoverButtonProps<
+    TSlotProps extends {},
+    TAsProp extends SupportedAs
+  > = TPassThroughProps<TSlotProps, TAsProp> & {
+    disabled?: boolean;
+  };
+</script>
+
 <script lang="ts">
   import { Keys } from "$lib/utils/keyboard";
   import {
@@ -13,14 +22,21 @@
   import { get_current_component } from "svelte/internal";
   import type { SupportedAs } from "$lib/internal/elements";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
-  import Render from "$lib/utils/Render.svelte";
+  import Render, { type TPassThroughProps } from "$lib/utils/Render.svelte";
   import { resolveButtonType } from "$lib/utils/resolve-button-type";
-  const forwardEvents = forwardEventsBuilder(get_current_component());
+
+  /***** Props *****/
+  type TAsProp = $$Generic<SupportedAs>;
+  type $$Props = TPopoverButtonProps<typeof slotProps, TAsProp>;
 
   export let as: SupportedAs = "button";
   export let use: HTMLActionArray = [];
+  export let disabled: boolean = false;
 
-  export let disabled: Boolean = false;
+  /***** Events *****/
+  const forwardEvents = forwardEventsBuilder(get_current_component());
+
+  /***** Component *****/
   let api = usePopoverContext("PopoverButton");
 
   let apiButton = $api.button;

--- a/src/lib/components/popover/PopoverGroup.svelte
+++ b/src/lib/components/popover/PopoverGroup.svelte
@@ -24,7 +24,8 @@
   import { get_current_component } from "svelte/internal";
   import type { SupportedAs } from "$lib/internal/elements";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
-  import Render, { type TPassThroughProps } from "$lib/utils/Render.svelte";
+  import Render from "$lib/utils/Render.svelte";
+  import type { TPassThroughProps } from "$lib/types";
 
   /***** Props *****/
   type TAsProp = $$Generic<SupportedAs>;

--- a/src/lib/components/popover/PopoverGroup.svelte
+++ b/src/lib/components/popover/PopoverGroup.svelte
@@ -14,7 +14,7 @@
   type TPopoverGroupProps<
     TSlotProps extends {},
     TAsProp extends SupportedAs
-  > = TPassThroughProps<TSlotProps, TAsProp> & {};
+  > = TPassThroughProps<TSlotProps, TAsProp, "div"> & {};
 </script>
 
 <script lang="ts">

--- a/src/lib/components/popover/PopoverGroup.svelte
+++ b/src/lib/components/popover/PopoverGroup.svelte
@@ -10,6 +10,11 @@
   export function usePopoverGroupContext(): PopoverGroupContext | undefined {
     return getContext(POPOVER_GROUP_CONTEXT_NAME);
   }
+
+  type TPopoverGroupProps<
+    TSlotProps extends {},
+    TAsProp extends SupportedAs
+  > = TPassThroughProps<TSlotProps, TAsProp> & {};
 </script>
 
 <script lang="ts">
@@ -19,12 +24,19 @@
   import { get_current_component } from "svelte/internal";
   import type { SupportedAs } from "$lib/internal/elements";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
-  import Render from "$lib/utils/Render.svelte";
-  const forwardEvents = forwardEventsBuilder(get_current_component());
+  import Render, { type TPassThroughProps } from "$lib/utils/Render.svelte";
+
+  /***** Props *****/
+  type TAsProp = $$Generic<SupportedAs>;
+  type $$Props = TPopoverGroupProps<typeof slotProps, TAsProp>;
 
   export let as: SupportedAs = "div";
   export let use: HTMLActionArray = [];
 
+  /***** Events *****/
+  const forwardEvents = forwardEventsBuilder(get_current_component());
+
+  /***** Component *****/
   let groupRef: HTMLDivElement | undefined;
   let popovers: PopoverRegisterBag[] = [];
 
@@ -65,15 +77,17 @@
     isFocusWithinPopoverGroup,
     closeOthers,
   });
+
+  $: slotProps = {};
 </script>
 
 <Render
   {...$$restProps}
   {as}
   use={[...use, forwardEvents]}
-  slotProps={{}}
+  {slotProps}
   name={"PopoverGroup"}
   bind:el={groupRef}
 >
-  <slot />
+  <slot {...slotProps} />
 </Render>

--- a/src/lib/components/popover/PopoverOverlay.svelte
+++ b/src/lib/components/popover/PopoverOverlay.svelte
@@ -1,3 +1,10 @@
+<script lang="ts" context="module">
+  type TPopoverOverlayProps<
+    TSlotProps extends {},
+    TAsProp extends SupportedAs
+  > = TPassThroughProps<TSlotProps, TAsProp> & {};
+</script>
+
 <script lang="ts">
   import { State, useOpenClosed } from "$lib/internal/open-closed";
   import { PopoverStates, usePopoverContext } from "./Popover.svelte";
@@ -5,13 +12,23 @@
   import { get_current_component } from "svelte/internal";
   import type { SupportedAs } from "$lib/internal/elements";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
-  import Render, { Features } from "$lib/utils/Render.svelte";
+  import Render, {
+    Features,
+    type TPassThroughProps,
+  } from "$lib/utils/Render.svelte";
   import { useId } from "$lib/hooks/use-id";
-  const forwardEvents = forwardEventsBuilder(get_current_component());
+
+  /***** Props *****/
+  type TAsProp = $$Generic<SupportedAs>;
+  type $$Props = TPopoverOverlayProps<typeof slotProps, TAsProp>;
 
   export let as: SupportedAs = "div";
   export let use: HTMLActionArray = [];
 
+  /***** Events *****/
+  const forwardEvents = forwardEventsBuilder(get_current_component());
+
+  /***** Component *****/
   let api = usePopoverContext("PopoverOverlay");
   let id = `headlessui-popover-overlay-${useId()}`;
 

--- a/src/lib/components/popover/PopoverOverlay.svelte
+++ b/src/lib/components/popover/PopoverOverlay.svelte
@@ -12,11 +12,9 @@
   import { get_current_component } from "svelte/internal";
   import type { SupportedAs } from "$lib/internal/elements";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
-  import Render, {
-    Features,
-    type TPassThroughProps,
-  } from "$lib/utils/Render.svelte";
+  import Render from "$lib/utils/Render.svelte";
   import { useId } from "$lib/hooks/use-id";
+  import { Features, type TPassThroughProps } from "$lib/types";
 
   /***** Props *****/
   type TAsProp = $$Generic<SupportedAs>;

--- a/src/lib/components/popover/PopoverOverlay.svelte
+++ b/src/lib/components/popover/PopoverOverlay.svelte
@@ -2,7 +2,7 @@
   type TPopoverOverlayProps<
     TSlotProps extends {},
     TAsProp extends SupportedAs
-  > = TPassThroughProps<TSlotProps, TAsProp> & {};
+  > = TPassThroughProps<TSlotProps, TAsProp, "div"> & {};
 </script>
 
 <script lang="ts">

--- a/src/lib/components/popover/PopoverPanel.svelte
+++ b/src/lib/components/popover/PopoverPanel.svelte
@@ -11,7 +11,7 @@
   type TPopoverPanelProps<
     TSlotProps extends {},
     TAsProp extends SupportedAs
-  > = TPassThroughProps<TSlotProps, TAsProp> & {
+  > = TPassThroughProps<TSlotProps, TAsProp, "div"> & {
     focus?: boolean;
     static?: boolean;
     unmount?: boolean;

--- a/src/lib/components/popover/PopoverPanel.svelte
+++ b/src/lib/components/popover/PopoverPanel.svelte
@@ -12,8 +12,15 @@
     TSlotProps extends {},
     TAsProp extends SupportedAs
   > = TPassThroughProps<TSlotProps, TAsProp, "div"> & {
+    /**
+     * Whether the `PopoverPanel` should trap focus.
+     * If true, focus will move inside the `PopoverPanel` when it is opened,
+     * and if focus leaves the `PopoverPanel` it will close.
+     */
     focus?: boolean;
+    /** Whether the element should ignore the internally managed open/closed state */
     static?: boolean;
+    /** Whether the element should be unmounted, instead of just hidden, based on the open/closed state	*/
     unmount?: boolean;
   };
 </script>

--- a/src/lib/components/popover/PopoverPanel.svelte
+++ b/src/lib/components/popover/PopoverPanel.svelte
@@ -7,6 +7,15 @@
     | undefined {
     return getContext(POPOVER_PANEL_CONTEXT_NAME);
   }
+
+  type TPopoverPanelProps<
+    TSlotProps extends {},
+    TAsProp extends SupportedAs
+  > = TPassThroughProps<TSlotProps, TAsProp> & {
+    focus?: boolean;
+    static?: boolean;
+    unmount?: boolean;
+  };
 </script>
 
 <script lang="ts">
@@ -25,14 +34,23 @@
   import { get_current_component } from "svelte/internal";
   import type { SupportedAs } from "$lib/internal/elements";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
-  import Render, { Features } from "$lib/utils/Render.svelte";
-  const forwardEvents = forwardEventsBuilder(get_current_component());
+  import Render, {
+    Features,
+    type TPassThroughProps,
+  } from "$lib/utils/Render.svelte";
+
+  /***** Props *****/
+  type TAsProp = $$Generic<SupportedAs>;
+  type $$Props = TPopoverPanelProps<typeof slotProps, TAsProp>;
 
   export let as: SupportedAs = "div";
   export let use: HTMLActionArray = [];
-
   export let focus = false;
 
+  /***** Events *****/
+  const forwardEvents = forwardEventsBuilder(get_current_component());
+
+  /***** Component *****/
   let api = usePopoverContext("PopoverPanel");
   setContext(POPOVER_PANEL_CONTEXT_NAME, $api.panelId);
 

--- a/src/lib/components/popover/PopoverPanel.svelte
+++ b/src/lib/components/popover/PopoverPanel.svelte
@@ -41,10 +41,8 @@
   import { get_current_component } from "svelte/internal";
   import type { SupportedAs } from "$lib/internal/elements";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
-  import Render, {
-    Features,
-    type TPassThroughProps,
-  } from "$lib/utils/Render.svelte";
+  import Render from "$lib/utils/Render.svelte";
+  import { Features, type TPassThroughProps } from "$lib/types";
 
   /***** Props *****/
   type TAsProp = $$Generic<SupportedAs>;

--- a/src/lib/components/radio-group/RadioGroup.svelte
+++ b/src/lib/components/radio-group/RadioGroup.svelte
@@ -48,7 +48,9 @@
     TSlotProps extends {},
     TAsProp extends SupportedAs
   > = TPassThroughProps<TSlotProps, TAsProp, "div"> & {
+    /** The currently selected value in the `RadioGroup` */
     value: StateDefinition["value"];
+    /** Whether the `RadioGroup` and all of its `RadioGroupOption`s are disabled */
     disabled?: boolean;
   };
 </script>

--- a/src/lib/components/radio-group/RadioGroup.svelte
+++ b/src/lib/components/radio-group/RadioGroup.svelte
@@ -61,7 +61,8 @@
   import { get_current_component } from "svelte/internal";
   import type { SupportedAs } from "$lib/internal/elements";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
-  import Render, { type TPassThroughProps } from "$lib/utils/Render.svelte";
+  import Render from "$lib/utils/Render.svelte";
+  import type { TPassThroughProps } from "$lib/types";
 
   /***** Props *****/
   type TAsProp = $$Generic<SupportedAs>;

--- a/src/lib/components/radio-group/RadioGroup.svelte
+++ b/src/lib/components/radio-group/RadioGroup.svelte
@@ -43,6 +43,14 @@
 
     return context;
   }
+
+  type TRadioGroupProps<
+    TSlotProps extends {},
+    TAsProp extends SupportedAs
+  > = TPassThroughProps<TSlotProps, TAsProp> & {
+    value: StateDefinition["value"];
+    disabled?: boolean;
+  };
 </script>
 
 <script lang="ts">
@@ -51,24 +59,30 @@
   import { get_current_component } from "svelte/internal";
   import type { SupportedAs } from "$lib/internal/elements";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
-  import Render from "$lib/utils/Render.svelte";
-  const forwardEvents = forwardEventsBuilder(get_current_component(), [
-    "change",
-  ]);
+  import Render, { type TPassThroughProps } from "$lib/utils/Render.svelte";
+
+  /***** Props *****/
+  type TAsProp = $$Generic<SupportedAs>;
+  type $$Props = TRadioGroupProps<typeof slotProps, TAsProp>;
 
   export let as: SupportedAs = "div";
   export let use: HTMLActionArray = [];
-
-  export let disabled = false;
   export let value: StateDefinition["value"];
+  export let disabled = false;
+
+  /***** Events *****/
+  const forwardEvents = forwardEventsBuilder(get_current_component(), [
+    "change",
+  ]);
+  const dispatch = createEventDispatcher<{
+    change: any;
+  }>();
+
+  /***** Component *****/
   let radioGroupRef: HTMLElement | null = null;
   let options: StateDefinition["options"] = [];
 
   let id = `headlessui-radiogroup-${useId()}`;
-
-  const dispatch = createEventDispatcher<{
-    change: any;
-  }>();
 
   let api = writable<StateDefinition>({
     options,
@@ -200,6 +214,8 @@
     id,
     role: "radiogroup",
   };
+
+  $: slotProps = {};
 </script>
 
 <DescriptionProvider name="RadioGroupDescription" let:describedby>
@@ -208,14 +224,14 @@
       {...{ ...$$restProps, ...propsWeControl }}
       {as}
       use={[...use, forwardEvents]}
-      slotProps={{}}
+      {slotProps}
       name={"RadioGroup"}
       bind:el={radioGroupRef}
       aria-labelledby={labelledby}
       aria-describedby={describedby}
       on:keydown={handleKeyDown}
     >
-      <slot />
+      <slot {...slotProps} />
     </Render>
   </LabelProvider>
 </DescriptionProvider>

--- a/src/lib/components/radio-group/RadioGroup.svelte
+++ b/src/lib/components/radio-group/RadioGroup.svelte
@@ -47,7 +47,7 @@
   type TRadioGroupProps<
     TSlotProps extends {},
     TAsProp extends SupportedAs
-  > = TPassThroughProps<TSlotProps, TAsProp> & {
+  > = TPassThroughProps<TSlotProps, TAsProp, "div"> & {
     value: StateDefinition["value"];
     disabled?: boolean;
   };

--- a/src/lib/components/radio-group/RadioGroupOption.svelte
+++ b/src/lib/components/radio-group/RadioGroupOption.svelte
@@ -1,3 +1,13 @@
+<script lang="ts" context="module">
+  type TRadioGroupOptionProps<
+    TSlotProps extends {},
+    TAsProp extends SupportedAs
+  > = TPassThroughProps<TSlotProps, TAsProp> & {
+    value: unknown;
+    disabled?: boolean;
+  };
+</script>
+
 <script lang="ts">
   import { onDestroy } from "svelte";
   import DescriptionProvider from "$lib/components/description/DescriptionProvider.svelte";
@@ -9,19 +19,26 @@
   import { get_current_component } from "svelte/internal";
   import type { SupportedAs } from "$lib/internal/elements";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
-  import Render from "$lib/utils/Render.svelte";
-  const forwardEvents = forwardEventsBuilder(get_current_component());
+  import Render, { type TPassThroughProps } from "$lib/utils/Render.svelte";
+
+  /***** Props *****/
+  type TAsProp = $$Generic<SupportedAs>;
+  type $$Props = TRadioGroupOptionProps<typeof slotProps, TAsProp>;
 
   export let as: SupportedAs = "div";
   export let use: HTMLActionArray = [];
+  export let value: unknown;
+  export let disabled: boolean = false;
 
+  /***** Events *****/
+  const forwardEvents = forwardEventsBuilder(get_current_component());
+
+  /***** Component *****/
   enum OptionState {
     Empty = 1 << 0,
     Active = 1 << 1,
   }
 
-  export let value: unknown;
-  export let disabled: boolean = false;
   let api = useRadioGroupContext("RadioGroupOption");
   let id = `headlessui-radiogroup-option-${useId()}`;
   let optionRef: HTMLElement | null = null;

--- a/src/lib/components/radio-group/RadioGroupOption.svelte
+++ b/src/lib/components/radio-group/RadioGroupOption.svelte
@@ -3,7 +3,12 @@
     TSlotProps extends {},
     TAsProp extends SupportedAs
   > = TPassThroughProps<TSlotProps, TAsProp, "div"> & {
+    /**
+     * The value of the `RadioGroupOption`.
+     * The type should match the type of the value prop in the `RadioGroup`
+     */
     value: unknown;
+    /** Whether the `RadioGroupOption` is disabled */
     disabled?: boolean;
   };
 </script>

--- a/src/lib/components/radio-group/RadioGroupOption.svelte
+++ b/src/lib/components/radio-group/RadioGroupOption.svelte
@@ -24,7 +24,8 @@
   import { get_current_component } from "svelte/internal";
   import type { SupportedAs } from "$lib/internal/elements";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
-  import Render, { type TPassThroughProps } from "$lib/utils/Render.svelte";
+  import Render from "$lib/utils/Render.svelte";
+  import type { TPassThroughProps } from "$lib/types";
 
   /***** Props *****/
   type TAsProp = $$Generic<SupportedAs>;

--- a/src/lib/components/radio-group/RadioGroupOption.svelte
+++ b/src/lib/components/radio-group/RadioGroupOption.svelte
@@ -2,7 +2,7 @@
   type TRadioGroupOptionProps<
     TSlotProps extends {},
     TAsProp extends SupportedAs
-  > = TPassThroughProps<TSlotProps, TAsProp> & {
+  > = TPassThroughProps<TSlotProps, TAsProp, "div"> & {
     value: unknown;
     disabled?: boolean;
   };

--- a/src/lib/components/switch/Switch.svelte
+++ b/src/lib/components/switch/Switch.svelte
@@ -2,7 +2,7 @@
   type TSwitchProps<
     TSlotProps extends {},
     TAsProp extends SupportedAs
-  > = TPassThroughProps<TSlotProps, TAsProp> & {
+  > = TPassThroughProps<TSlotProps, TAsProp, "button"> & {
     checked: boolean;
   };
 </script>

--- a/src/lib/components/switch/Switch.svelte
+++ b/src/lib/components/switch/Switch.svelte
@@ -1,3 +1,12 @@
+<script lang="ts" context="module">
+  type TSwitchProps<
+    TSlotProps extends {},
+    TAsProp extends SupportedAs
+  > = TPassThroughProps<TSlotProps, TAsProp> & {
+    checked: boolean;
+  };
+</script>
+
 <script lang="ts">
   import { useSwitchContext } from "./SwitchGroup.svelte";
   import { useLabelContext } from "$lib/components/label/LabelProvider.svelte";
@@ -9,18 +18,26 @@
   import { get_current_component } from "svelte/internal";
   import type { SupportedAs } from "$lib/internal/elements";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
-  import Render from "$lib/utils/Render.svelte";
+  import Render, { type TPassThroughProps } from "$lib/utils/Render.svelte";
   import { resolveButtonType } from "$lib/utils/resolve-button-type";
+
+  /***** Props *****/
+  type TAsProp = $$Generic<SupportedAs>;
+  type $$Props = TSwitchProps<typeof slotProps, TAsProp>;
+
+  export let as: SupportedAs = "button";
+  export let use: HTMLActionArray = [];
+  export let checked = false;
+
+  /***** Events *****/
   const forwardEvents = forwardEventsBuilder(get_current_component(), [
     "change",
   ]);
-  export let as: SupportedAs = "button";
-  export let use: HTMLActionArray = [];
-
   const dispatch = createEventDispatcher<{
     change: boolean;
   }>();
-  export let checked = false;
+
+  /***** Component *****/
   let api = useSwitchContext();
   let labelContext = useLabelContext();
   let descriptionContext = useDescriptionContext();

--- a/src/lib/components/switch/Switch.svelte
+++ b/src/lib/components/switch/Switch.svelte
@@ -3,6 +3,7 @@
     TSlotProps extends {},
     TAsProp extends SupportedAs
   > = TPassThroughProps<TSlotProps, TAsProp, "button"> & {
+    /** Whether the switch is checked */
     checked: boolean;
   };
 </script>

--- a/src/lib/components/switch/Switch.svelte
+++ b/src/lib/components/switch/Switch.svelte
@@ -19,8 +19,9 @@
   import { get_current_component } from "svelte/internal";
   import type { SupportedAs } from "$lib/internal/elements";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
-  import Render, { type TPassThroughProps } from "$lib/utils/Render.svelte";
+  import Render from "$lib/utils/Render.svelte";
   import { resolveButtonType } from "$lib/utils/resolve-button-type";
+  import type { TPassThroughProps } from "$lib/types";
 
   /***** Props *****/
   type TAsProp = $$Generic<SupportedAs>;

--- a/src/lib/components/switch/SwitchGroup.svelte
+++ b/src/lib/components/switch/SwitchGroup.svelte
@@ -7,6 +7,11 @@
   export function useSwitchContext(): Writable<StateDefinition> | undefined {
     return getContext(SWITCH_CONTEXT_NAME);
   }
+
+  type TSwitchGroupProps<
+    TSlotProps extends {},
+    TAsProp extends SupportedAs
+  > = TPassThroughProps<TSlotProps, TAsProp> & {};
 </script>
 
 <script lang="ts">
@@ -19,11 +24,19 @@
   import { get_current_component } from "svelte/internal";
   import type { SupportedAs } from "$lib/internal/elements";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
-  import Render from "$lib/utils/Render.svelte";
-  const forwardEvents = forwardEventsBuilder(get_current_component());
+  import Render, { type TPassThroughProps } from "$lib/utils/Render.svelte";
+
+  /***** Props *****/
+  type TAsProp = $$Generic<SupportedAs>;
+  type $$Props = TSwitchGroupProps<typeof slotProps, TAsProp>;
+
   export let as: SupportedAs = "div";
   export let use: HTMLActionArray = [];
 
+  /***** Events *****/
+  const forwardEvents = forwardEventsBuilder(get_current_component());
+
+  /***** Component *****/
   let switchStore: StateDefinition["switchStore"] = writable(null);
 
   let api = writable<StateDefinition>({
@@ -36,18 +49,20 @@
     $switchStore.click();
     $switchStore.focus({ preventScroll: true });
   }
+
+  $: slotProps = {};
 </script>
 
 <Render
   {...$$restProps}
   {as}
   use={[...use, forwardEvents]}
-  slotProps={{}}
+  {slotProps}
   name={"SwitchGroup"}
 >
   <DescriptionProvider name="SwitchDescription">
     <LabelProvider name="SwitchLabel" {onClick}>
-      <slot />
+      <slot {...slotProps} />
     </LabelProvider>
   </DescriptionProvider>
 </Render>

--- a/src/lib/components/switch/SwitchGroup.svelte
+++ b/src/lib/components/switch/SwitchGroup.svelte
@@ -11,7 +11,7 @@
   type TSwitchGroupProps<
     TSlotProps extends {},
     TAsProp extends SupportedAs
-  > = TPassThroughProps<TSlotProps, TAsProp> & {};
+  > = TPassThroughProps<TSlotProps, TAsProp, "div"> & {};
 </script>
 
 <script lang="ts">

--- a/src/lib/components/switch/SwitchGroup.svelte
+++ b/src/lib/components/switch/SwitchGroup.svelte
@@ -24,7 +24,8 @@
   import { get_current_component } from "svelte/internal";
   import type { SupportedAs } from "$lib/internal/elements";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
-  import Render, { type TPassThroughProps } from "$lib/utils/Render.svelte";
+  import Render from "$lib/utils/Render.svelte";
+  import type { TPassThroughProps } from "$lib/types";
 
   /***** Props *****/
   type TAsProp = $$Generic<SupportedAs>;

--- a/src/lib/components/tabs/Tab.svelte
+++ b/src/lib/components/tabs/Tab.svelte
@@ -2,7 +2,7 @@
   type TTabProps<
     TSlotProps extends {},
     TAsProp extends SupportedAs
-  > = TPassThroughProps<TSlotProps, TAsProp> & {
+  > = TPassThroughProps<TSlotProps, TAsProp, "button"> & {
     disabled?: boolean;
   };
 </script>

--- a/src/lib/components/tabs/Tab.svelte
+++ b/src/lib/components/tabs/Tab.svelte
@@ -1,3 +1,12 @@
+<script lang="ts" context="module">
+  type TTabProps<
+    TSlotProps extends {},
+    TAsProp extends SupportedAs
+  > = TPassThroughProps<TSlotProps, TAsProp> & {
+    disabled?: boolean;
+  };
+</script>
+
 <script lang="ts">
   import { onMount } from "svelte";
   import { Focus, focusIn } from "$lib/utils/focus-management";
@@ -9,15 +18,21 @@
   import { get_current_component } from "svelte/internal";
   import type { SupportedAs } from "$lib/internal/elements";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
-  import Render from "$lib/utils/Render.svelte";
+  import Render, { type TPassThroughProps } from "$lib/utils/Render.svelte";
   import { resolveButtonType } from "$lib/utils/resolve-button-type";
-  const forwardEvents = forwardEventsBuilder(get_current_component());
+
+  /***** Props *****/
+  type TAsProp = $$Generic<SupportedAs>;
+  type $$Props = TTabProps<typeof slotProps, TAsProp>;
 
   export let as: SupportedAs = "button";
   export let use: HTMLActionArray = [];
-
   export let disabled = false;
 
+  /***** Events *****/
+  const forwardEvents = forwardEventsBuilder(get_current_component());
+
+  /***** Component *****/
   let api = useTabsContext("Tab");
   let id = `headlessui-tabs-tab-${useId()}`;
   let tabRef: HTMLElement | null = null;

--- a/src/lib/components/tabs/Tab.svelte
+++ b/src/lib/components/tabs/Tab.svelte
@@ -3,6 +3,7 @@
     TSlotProps extends {},
     TAsProp extends SupportedAs
   > = TPassThroughProps<TSlotProps, TAsProp, "button"> & {
+    /** Whether the `Tab` is currently disabled */
     disabled?: boolean;
   };
 </script>

--- a/src/lib/components/tabs/Tab.svelte
+++ b/src/lib/components/tabs/Tab.svelte
@@ -19,8 +19,9 @@
   import { get_current_component } from "svelte/internal";
   import type { SupportedAs } from "$lib/internal/elements";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
-  import Render, { type TPassThroughProps } from "$lib/utils/Render.svelte";
+  import Render from "$lib/utils/Render.svelte";
   import { resolveButtonType } from "$lib/utils/resolve-button-type";
+  import type { TPassThroughProps } from "$lib/types";
 
   /***** Props *****/
   type TAsProp = $$Generic<SupportedAs>;

--- a/src/lib/components/tabs/TabGroup.svelte
+++ b/src/lib/components/tabs/TabGroup.svelte
@@ -68,7 +68,8 @@
   import { get_current_component } from "svelte/internal";
   import type { SupportedAs } from "$lib/internal/elements";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
-  import Render, { type TPassThroughProps } from "$lib/utils/Render.svelte";
+  import Render from "$lib/utils/Render.svelte";
+  import type { TPassThroughProps } from "$lib/types";
 
   /***** Props *****/
   type TAsProp = $$Generic<SupportedAs>;

--- a/src/lib/components/tabs/TabGroup.svelte
+++ b/src/lib/components/tabs/TabGroup.svelte
@@ -40,7 +40,7 @@
   type TTabGroupProps<
     TSlotProps extends {},
     TAsProp extends SupportedAs
-  > = TPassThroughProps<TSlotProps, TAsProp> & {
+  > = TPassThroughProps<TSlotProps, TAsProp, "div"> & {
     defaultIndex?: number;
     vertical?: boolean;
     manual?: boolean;

--- a/src/lib/components/tabs/TabGroup.svelte
+++ b/src/lib/components/tabs/TabGroup.svelte
@@ -36,6 +36,15 @@
 
     return context;
   }
+
+  type TTabGroupProps<
+    TSlotProps extends {},
+    TAsProp extends SupportedAs
+  > = TPassThroughProps<TSlotProps, TAsProp> & {
+    defaultIndex?: number;
+    vertical?: boolean;
+    manual?: boolean;
+  };
 </script>
 
 <script lang="ts">
@@ -52,10 +61,11 @@
   import { get_current_component } from "svelte/internal";
   import type { SupportedAs } from "$lib/internal/elements";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
-  import Render from "$lib/utils/Render.svelte";
-  const forwardEvents = forwardEventsBuilder(get_current_component(), [
-    "change",
-  ]);
+  import Render, { type TPassThroughProps } from "$lib/utils/Render.svelte";
+
+  /***** Props *****/
+  type TAsProp = $$Generic<SupportedAs>;
+  type $$Props = TTabGroupProps<typeof slotProps, TAsProp>;
 
   export let as: SupportedAs = "div";
   export let use: HTMLActionArray = [];
@@ -63,12 +73,17 @@
   export let vertical = false;
   export let manual = false;
 
+  /***** Events *****/
+  const forwardEvents = forwardEventsBuilder(get_current_component(), [
+    "change",
+  ]);
+  const dispatch = createEventDispatcher();
+
+  /***** Component *****/
   let selectedIndex: StateDefinition["selectedIndex"] = null;
   let tabs: StateDefinition["tabs"] = [];
   let panels: StateDefinition["panels"] = [];
   let listRef: StateDefinition["listRef"] = writable(null);
-
-  const dispatch = createEventDispatcher();
 
   let api = writable<StateDefinition>({
     selectedIndex,

--- a/src/lib/components/tabs/TabGroup.svelte
+++ b/src/lib/components/tabs/TabGroup.svelte
@@ -41,8 +41,15 @@
     TSlotProps extends {},
     TAsProp extends SupportedAs
   > = TPassThroughProps<TSlotProps, TAsProp, "div"> & {
+    /** The index of the default selected tab */
     defaultIndex?: number;
+    /** Whether the orientation of the `TabList` is vertical instead of horizontal */
     vertical?: boolean;
+    /**
+     * Whether, in keyboard navigation, the Enter or Space key is necessary to change tabs.
+     * By default, the arrow keys will change tabs automatically without hitting Enter/Space.
+     * This has no impact on mouse behavior
+     */
     manual?: boolean;
   };
 </script>

--- a/src/lib/components/tabs/TabList.svelte
+++ b/src/lib/components/tabs/TabList.svelte
@@ -1,15 +1,29 @@
+<script lang="ts" context="module">
+  type TTabListProps<
+    TSlotProps extends {},
+    TAsProp extends SupportedAs
+  > = TPassThroughProps<TSlotProps, TAsProp> & {};
+</script>
+
 <script lang="ts">
   import { useTabsContext } from "./TabGroup.svelte";
   import { forwardEventsBuilder } from "$lib/internal/forwardEventsBuilder";
   import { get_current_component } from "svelte/internal";
   import type { SupportedAs } from "$lib/internal/elements";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
-  import Render from "$lib/utils/Render.svelte";
-  const forwardEvents = forwardEventsBuilder(get_current_component());
+  import Render, { type TPassThroughProps } from "$lib/utils/Render.svelte";
+
+  /***** Props *****/
+  type TAsProp = $$Generic<SupportedAs>;
+  type $$Props = TTabListProps<typeof slotProps, TAsProp>;
 
   export let as: SupportedAs = "div";
   export let use: HTMLActionArray = [];
 
+  /***** Events *****/
+  const forwardEvents = forwardEventsBuilder(get_current_component());
+
+  /***** Component *****/
   let api = useTabsContext("TabList");
   let listRef = $api.listRef;
 

--- a/src/lib/components/tabs/TabList.svelte
+++ b/src/lib/components/tabs/TabList.svelte
@@ -2,7 +2,7 @@
   type TTabListProps<
     TSlotProps extends {},
     TAsProp extends SupportedAs
-  > = TPassThroughProps<TSlotProps, TAsProp> & {};
+  > = TPassThroughProps<TSlotProps, TAsProp, "div"> & {};
 </script>
 
 <script lang="ts">

--- a/src/lib/components/tabs/TabList.svelte
+++ b/src/lib/components/tabs/TabList.svelte
@@ -11,7 +11,8 @@
   import { get_current_component } from "svelte/internal";
   import type { SupportedAs } from "$lib/internal/elements";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
-  import Render, { type TPassThroughProps } from "$lib/utils/Render.svelte";
+  import Render from "$lib/utils/Render.svelte";
+  import type { TPassThroughProps } from "$lib/types";
 
   /***** Props *****/
   type TAsProp = $$Generic<SupportedAs>;

--- a/src/lib/components/tabs/TabPanel.svelte
+++ b/src/lib/components/tabs/TabPanel.svelte
@@ -2,7 +2,7 @@
   type TTabPanelProps<
     TSlotProps extends {},
     TAsProp extends SupportedAs
-  > = TPassThroughProps<TSlotProps, TAsProp> & {};
+  > = TPassThroughProps<TSlotProps, TAsProp, "div"> & {};
 </script>
 
 <script lang="ts">

--- a/src/lib/components/tabs/TabPanel.svelte
+++ b/src/lib/components/tabs/TabPanel.svelte
@@ -1,3 +1,10 @@
+<script lang="ts" context="module">
+  type TTabPanelProps<
+    TSlotProps extends {},
+    TAsProp extends SupportedAs
+  > = TPassThroughProps<TSlotProps, TAsProp> & {};
+</script>
+
 <script lang="ts">
   import { onMount } from "svelte";
   import { useTabsContext } from "./TabGroup.svelte";
@@ -6,13 +13,23 @@
   import { get_current_component } from "svelte/internal";
   import type { SupportedAs } from "$lib/internal/elements";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
-  import Render, { Features } from "$lib/utils/Render.svelte";
+  import Render, {
+    Features,
+    type TPassThroughProps,
+  } from "$lib/utils/Render.svelte";
   import { writable } from "svelte/store";
-  const forwardEvents = forwardEventsBuilder(get_current_component());
+
+  /***** Props *****/
+  type TAsProp = $$Generic<SupportedAs>;
+  type $$Props = TTabPanelProps<typeof slotProps, TAsProp>;
 
   export let as: SupportedAs = "div";
   export let use: HTMLActionArray = [];
 
+  /***** Events *****/
+  const forwardEvents = forwardEventsBuilder(get_current_component());
+
+  /***** Component *****/
   let elementRef = writable<HTMLElement | null>(null);
   let api = useTabsContext("TabPanel");
   let id = `headlessui-tabs-panel-${useId()}`;

--- a/src/lib/components/tabs/TabPanel.svelte
+++ b/src/lib/components/tabs/TabPanel.svelte
@@ -13,11 +13,9 @@
   import { get_current_component } from "svelte/internal";
   import type { SupportedAs } from "$lib/internal/elements";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
-  import Render, {
-    Features,
-    type TPassThroughProps,
-  } from "$lib/utils/Render.svelte";
+  import Render from "$lib/utils/Render.svelte";
   import { writable } from "svelte/store";
+  import { Features, type TPassThroughProps } from "$lib/types";
 
   /***** Props *****/
   type TAsProp = $$Generic<SupportedAs>;

--- a/src/lib/components/tabs/TabPanels.svelte
+++ b/src/lib/components/tabs/TabPanels.svelte
@@ -1,15 +1,29 @@
+<script lang="ts" context="module">
+  type TTabPanelsProps<
+    TSlotProps extends {},
+    TAsProp extends SupportedAs
+  > = TPassThroughProps<TSlotProps, TAsProp> & {};
+</script>
+
 <script lang="ts">
   import { useTabsContext } from "./TabGroup.svelte";
   import { forwardEventsBuilder } from "$lib/internal/forwardEventsBuilder";
   import { get_current_component } from "svelte/internal";
   import type { SupportedAs } from "$lib/internal/elements";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
-  import Render from "$lib/utils/Render.svelte";
-  const forwardEvents = forwardEventsBuilder(get_current_component());
+  import Render, { type TPassThroughProps } from "$lib/utils/Render.svelte";
+
+  /***** Props *****/
+  type TAsProp = $$Generic<SupportedAs>;
+  type $$Props = TTabPanelsProps<typeof slotProps, TAsProp>;
 
   export let as: SupportedAs = "div";
   export let use: HTMLActionArray = [];
 
+  /***** Events *****/
+  const forwardEvents = forwardEventsBuilder(get_current_component());
+
+  /***** Component *****/
   let api = useTabsContext("TabPanels");
   $: slotProps = { selectedIndex: $api.selectedIndex };
 </script>

--- a/src/lib/components/tabs/TabPanels.svelte
+++ b/src/lib/components/tabs/TabPanels.svelte
@@ -2,7 +2,7 @@
   type TTabPanelsProps<
     TSlotProps extends {},
     TAsProp extends SupportedAs
-  > = TPassThroughProps<TSlotProps, TAsProp> & {};
+  > = TPassThroughProps<TSlotProps, TAsProp, "div"> & {};
 </script>
 
 <script lang="ts">

--- a/src/lib/components/tabs/TabPanels.svelte
+++ b/src/lib/components/tabs/TabPanels.svelte
@@ -11,7 +11,8 @@
   import { get_current_component } from "svelte/internal";
   import type { SupportedAs } from "$lib/internal/elements";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
-  import Render, { type TPassThroughProps } from "$lib/utils/Render.svelte";
+  import Render from "$lib/utils/Render.svelte";
+  import type { TPassThroughProps } from "$lib/types";
 
   /***** Props *****/
   type TAsProp = $$Generic<SupportedAs>;

--- a/src/lib/components/transitions/TransitionChild.svelte
+++ b/src/lib/components/transitions/TransitionChild.svelte
@@ -1,9 +1,5 @@
 <script lang="ts" context="module">
-  export type TTransitionChildProps<
-    TAsProp extends SupportedAs,
-    TDefaultAs
-  > = Omit<TPassThroughProps<{}, TAsProp, TDefaultAs>, "class"> & {
-    /** Classes to add to the transitioning element during the entire enter phase */
+  export type TTransitionProps = {
     enter?: string;
     /** Classes to add to the transitioning element before the enter phase starts */
     enterFrom?: string;
@@ -22,9 +18,23 @@
     leaveTo?: string;
     /** Whether the element should be unmounted, instead of just hidden, based on the open/closed state */
     unmount?: boolean;
-    /** The class attribute for the transition element. These classes will always be present. */
+    /**
+     * A list of actions to apply to the component's HTML element.
+     *
+     * Each action must take the form `[action]` or `[action, options]`:
+     *
+     * use={[[action1], [action2, action2Options], [action3]]}
+     */
+    use?: HTMLActionArray;
+    /** The class attribute for this component. It will always be present. */
     class?: string;
+    /** The style attribute for this component. It will always be present. */
+    style?: string;
+    /** The element this component should render as */
+    as?: SupportedAs;
   };
+
+  type TTransitionChildProps = TTransitionProps & Omit<TRestProps<"div">, "as">;
 </script>
 
 <script lang="ts">
@@ -47,15 +57,11 @@
   import { get_current_component } from "svelte/internal";
   import type { SupportedAs } from "$lib/internal/elements";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
-  import Render, {
-    Features,
-    RenderStrategy,
-    type TPassThroughProps,
-  } from "$lib/utils/Render.svelte";
+  import Render, { RenderStrategy } from "$lib/utils/Render.svelte";
+  import { Features, type TRestProps } from "$lib/types";
 
   /***** Props *****/
-  type TAsProp = $$Generic<SupportedAs>;
-  type $$Props = TTransitionChildProps<TAsProp, "div">;
+  type $$Props = TTransitionChildProps;
 
   export let as: SupportedAs = "div";
   export let use: HTMLActionArray = [];

--- a/src/lib/components/transitions/TransitionChild.svelte
+++ b/src/lib/components/transitions/TransitionChild.svelte
@@ -2,15 +2,27 @@
   export type TTransitionChildProps<
     TAsProp extends SupportedAs,
     TDefaultAs
-  > = TPassThroughProps<{}, TAsProp, TDefaultAs> & {
+  > = Omit<TPassThroughProps<{}, TAsProp, TDefaultAs>, "class"> & {
+    /** Classes to add to the transitioning element during the entire enter phase */
     enter?: string;
+    /** Classes to add to the transitioning element before the enter phase starts */
     enterFrom?: string;
+    /** Classes to add to the transitioning element immediately after the enter phase starts */
     enterTo?: string;
+    /**
+     * Classes to add to the transitioning element once the transition is done.
+     * These classes will persist after that until the leave phase
+     */
     entered?: string;
+    /** Classes to add to the transitioning element during the entire leave phase */
     leave?: string;
+    /** Classes to add to the transitioning element before the leave phase starts */
     leaveFrom?: string;
+    /** Classes to add to the transitioning element immediately after the leave phase starts */
     leaveTo?: string;
+    /** Whether the element should be unmounted, instead of just hidden, based on the open/closed state */
     unmount?: boolean;
+    /** The class attribute for the transition element. These classes will always be present. */
     class?: string;
   };
 </script>

--- a/src/lib/components/transitions/TransitionChild.svelte
+++ b/src/lib/components/transitions/TransitionChild.svelte
@@ -1,16 +1,18 @@
 <script lang="ts" context="module">
-  export type TTransitionChildProps<TAsProp extends SupportedAs> =
-    TPassThroughProps<{}, TAsProp> & {
-      enter?: string;
-      enterFrom?: string;
-      enterTo?: string;
-      entered?: string;
-      leave?: string;
-      leaveFrom?: string;
-      leaveTo?: string;
-      unmount?: boolean;
-      class?: string;
-    };
+  export type TTransitionChildProps<
+    TAsProp extends SupportedAs,
+    TDefaultAs
+  > = TPassThroughProps<{}, TAsProp, TDefaultAs> & {
+    enter?: string;
+    enterFrom?: string;
+    enterTo?: string;
+    entered?: string;
+    leave?: string;
+    leaveFrom?: string;
+    leaveTo?: string;
+    unmount?: boolean;
+    class?: string;
+  };
 </script>
 
 <script lang="ts">
@@ -41,7 +43,7 @@
 
   /***** Props *****/
   type TAsProp = $$Generic<SupportedAs>;
-  type $$Props = TTransitionChildProps<TAsProp>;
+  type $$Props = TTransitionChildProps<TAsProp, "div">;
 
   export let as: SupportedAs = "div";
   export let use: HTMLActionArray = [];

--- a/src/lib/components/transitions/TransitionChild.svelte
+++ b/src/lib/components/transitions/TransitionChild.svelte
@@ -1,3 +1,18 @@
+<script lang="ts" context="module">
+  export type TTransitionChildProps<TAsProp extends SupportedAs> =
+    TPassThroughProps<{}, TAsProp> & {
+      enter?: string;
+      enterFrom?: string;
+      enterTo?: string;
+      entered?: string;
+      leave?: string;
+      leaveFrom?: string;
+      leaveTo?: string;
+      unmount?: boolean;
+      class?: string;
+    };
+</script>
+
 <script lang="ts">
   import { createEventDispatcher, onMount, setContext } from "svelte";
   import { writable } from "svelte/store";
@@ -18,13 +33,15 @@
   import { get_current_component } from "svelte/internal";
   import type { SupportedAs } from "$lib/internal/elements";
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
-  import Render, { Features, RenderStrategy } from "$lib/utils/Render.svelte";
-  const forwardEvents = forwardEventsBuilder(get_current_component(), [
-    "beforeEnter",
-    "beforeLeave",
-    "afterEnter",
-    "afterLeave",
-  ]);
+  import Render, {
+    Features,
+    RenderStrategy,
+    type TPassThroughProps,
+  } from "$lib/utils/Render.svelte";
+
+  /***** Props *****/
+  type TAsProp = $$Generic<SupportedAs>;
+  type $$Props = TTransitionChildProps<TAsProp>;
 
   export let as: SupportedAs = "div";
   export let use: HTMLActionArray = [];
@@ -37,6 +54,7 @@
   export let leaveFrom = "";
   export let leaveTo = "";
 
+  /***** Events *****/
   const dispatch = createEventDispatcher<{
     afterEnter: null;
     afterLeave: null;
@@ -44,6 +62,14 @@
     beforeLeave: null;
   }>();
 
+  const forwardEvents = forwardEventsBuilder(get_current_component(), [
+    "beforeEnter",
+    "beforeLeave",
+    "afterEnter",
+    "afterLeave",
+  ]);
+
+  /***** Component *****/
   let container: HTMLElement | null = null;
 
   let transitionContext = useTransitionContext();

--- a/src/lib/components/transitions/TransitionChildWrapper.svelte
+++ b/src/lib/components/transitions/TransitionChildWrapper.svelte
@@ -19,7 +19,7 @@
   /***** Props *****/
 
   type TAsProp = $$Generic<SupportedAs>;
-  type $$Props = TTransitionRootProps<TAsProp>;
+  type $$Props = TTransitionRootProps<TAsProp, "div">;
 
   export let as: SupportedAs = "div";
   export let use: HTMLActionArray = [];

--- a/src/lib/components/transitions/TransitionChildWrapper.svelte
+++ b/src/lib/components/transitions/TransitionChildWrapper.svelte
@@ -18,8 +18,7 @@
 
   /***** Props *****/
 
-  type TAsProp = $$Generic<SupportedAs>;
-  type $$Props = TTransitionRootProps<TAsProp, "div">;
+  type $$Props = TTransitionRootProps;
 
   export let as: SupportedAs = "div";
   export let use: HTMLActionArray = [];

--- a/src/lib/components/transitions/TransitionChildWrapper.svelte
+++ b/src/lib/components/transitions/TransitionChildWrapper.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
   import { hasOpenClosed } from "$lib/internal/open-closed";
   import TransitionChild from "./TransitionChild.svelte";
-  import TransitionRoot from "./TransitionRoot.svelte";
+  import TransitionRoot, {
+    type TTransitionRootProps,
+  } from "./TransitionRoot.svelte";
   import { forwardEventsBuilder } from "$lib/internal/forwardEventsBuilder";
   import { get_current_component } from "svelte/internal";
   import type { SupportedAs } from "$lib/internal/elements";
@@ -14,9 +16,17 @@
     "afterLeave",
   ]);
 
+  /***** Props *****/
+
+  type TAsProp = $$Generic<SupportedAs>;
+  type $$Props = TTransitionRootProps<TAsProp>;
+
   export let as: SupportedAs = "div";
   export let use: HTMLActionArray = [];
 
+  /***** Events *****/
+
+  /***** Component *****/
   let hasTransition = hasTransitionContext();
   let hasOpen = hasOpenClosed();
 </script>

--- a/src/lib/components/transitions/TransitionRoot.svelte
+++ b/src/lib/components/transitions/TransitionRoot.svelte
@@ -1,13 +1,11 @@
 <script lang="ts" context="module">
-  export type TTransitionRootProps<
-    TAsProp extends SupportedAs,
-    TDefaultAs
-  > = TTransitionChildProps<TAsProp, TDefaultAs> & {
-    /** Whether the children should be shown */
-    show?: boolean;
-    /** Whether the transition should run on initial mount */
-    appear?: boolean;
-  };
+  export type TTransitionRootProps = TTransitionProps &
+    Omit<TRestProps<"div">, "as"> & {
+      /** Whether the children should be shown */
+      show?: boolean;
+      /** Whether the transition should run on initial mount */
+      appear?: boolean;
+    };
 </script>
 
 <script lang="ts">
@@ -16,7 +14,7 @@
   import { match } from "$lib/utils/match";
   import { State, useOpenClosed } from "$lib/internal/open-closed";
   import TransitionChild, {
-    type TTransitionChildProps,
+    type TTransitionProps,
   } from "$lib/components/transitions/TransitionChild.svelte";
   import { forwardEventsBuilder } from "$lib/internal/forwardEventsBuilder";
   import { get_current_component } from "svelte/internal";
@@ -33,6 +31,7 @@
     TreeStates,
     useNesting,
   } from "./common.svelte";
+  import type { TRestProps } from "$lib/types";
   const forwardEvents = forwardEventsBuilder(get_current_component(), [
     "beforeEnter",
     "beforeLeave",
@@ -41,8 +40,7 @@
   ]);
 
   /***** Props *****/
-  type TAsProp = $$Generic<SupportedAs>;
-  type $$Props = TTransitionRootProps<TAsProp, "div">;
+  type $$Props = TTransitionRootProps;
 
   export let as: SupportedAs = "div";
   export let use: HTMLActionArray = [];

--- a/src/lib/components/transitions/TransitionRoot.svelte
+++ b/src/lib/components/transitions/TransitionRoot.svelte
@@ -1,9 +1,19 @@
+<script lang="ts" context="module">
+  export type TTransitionRootProps<TAsProp extends SupportedAs> =
+    TTransitionChildProps<TAsProp> & {
+      show?: boolean;
+      appear?: boolean;
+    };
+</script>
+
 <script lang="ts">
   import { onMount, setContext } from "svelte";
   import { writable } from "svelte/store";
   import { match } from "$lib/utils/match";
   import { State, useOpenClosed } from "$lib/internal/open-closed";
-  import TransitionChild from "$lib/components/transitions/TransitionChild.svelte";
+  import TransitionChild, {
+    type TTransitionChildProps,
+  } from "$lib/components/transitions/TransitionChild.svelte";
   import { forwardEventsBuilder } from "$lib/internal/forwardEventsBuilder";
   import { get_current_component } from "svelte/internal";
   import type { SupportedAs } from "$lib/internal/elements";
@@ -26,12 +36,18 @@
     "afterLeave",
   ]);
 
+  /***** Props *****/
+  type TAsProp = $$Generic<SupportedAs>;
+  type $$Props = TTransitionRootProps<TAsProp>;
+
   export let as: SupportedAs = "div";
   export let use: HTMLActionArray = [];
-
   export let show: boolean | undefined = undefined;
   export let appear = false;
 
+  /***** Events *****/
+
+  /***** Component *****/
   let openClosedState = useOpenClosed();
 
   function computeShow(

--- a/src/lib/components/transitions/TransitionRoot.svelte
+++ b/src/lib/components/transitions/TransitionRoot.svelte
@@ -3,7 +3,9 @@
     TAsProp extends SupportedAs,
     TDefaultAs
   > = TTransitionChildProps<TAsProp, TDefaultAs> & {
+    /** Whether the children should be shown */
     show?: boolean;
+    /** Whether the transition should run on initial mount */
     appear?: boolean;
   };
 </script>

--- a/src/lib/components/transitions/TransitionRoot.svelte
+++ b/src/lib/components/transitions/TransitionRoot.svelte
@@ -1,9 +1,11 @@
 <script lang="ts" context="module">
-  export type TTransitionRootProps<TAsProp extends SupportedAs> =
-    TTransitionChildProps<TAsProp> & {
-      show?: boolean;
-      appear?: boolean;
-    };
+  export type TTransitionRootProps<
+    TAsProp extends SupportedAs,
+    TDefaultAs
+  > = TTransitionChildProps<TAsProp, TDefaultAs> & {
+    show?: boolean;
+    appear?: boolean;
+  };
 </script>
 
 <script lang="ts">
@@ -38,7 +40,7 @@
 
   /***** Props *****/
   type TAsProp = $$Generic<SupportedAs>;
-  type $$Props = TTransitionRootProps<TAsProp>;
+  type $$Props = TTransitionRootProps<TAsProp, "div">;
 
   export let as: SupportedAs = "div";
   export let use: HTMLActionArray = [];

--- a/src/lib/internal/elements/index.ts
+++ b/src/lib/internal/elements/index.ts
@@ -82,7 +82,7 @@ const components = {
 };
 
 export type SupportedElement = keyof typeof components;
-export type SupportedAs = SupportedElement | SvelteComponent;
+export type SupportedAs = SupportedElement | typeof SvelteComponent;
 
 export function getElementComponent(name: SupportedElement) {
   return components[name];

--- a/src/lib/test-utils/TestRenderer.svelte
+++ b/src/lib/test-utils/TestRenderer.svelte
@@ -10,7 +10,7 @@
   }
   type SingleComponent =
     | string
-    | [SvelteComponent, ComponentProps, TestRendererProps];
+    | [typeof SvelteComponent, ComponentProps, TestRendererProps];
   export type TestRendererProps =
     | undefined
     | SingleComponent

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,89 @@
+/// <reference types="svelte2tsx/svelte-jsx" />
+
+import type { HTMLActionArray } from "./hooks/use-actions";
+import type { SupportedAs, SupportedElement } from "./internal/elements";
+
+// Can't figure out how to import from Render.svelte, so this must be moved here instead.
+export enum Features {
+  /** No features at all */
+  None = 0,
+
+  /**
+   * When used, this will allow us to use one of the render strategies.
+   *
+   * **The render strategies are:**
+   *    - **Unmount**   _(Will unmount the component.)_
+   *    - **Hidden**    _(Will hide the component using the [hidden] attribute.)_
+   */
+  RenderStrategy = 1,
+
+  /**
+   * When used, this will allow the user of our component to be in control. This can be used when
+   * you want to transition based on some state.
+   */
+  Static = 2,
+}
+
+export type TRestProps<T> = T extends SupportedElement
+  ? Omit<
+    svelte.JSX.HTMLAttributes<HTMLElementTagNameMap[T]>,
+    "class" | "style"
+  >
+  : {};
+
+export type TResolveAs<TAsProp, TDefaultAs> = SupportedAs extends TAsProp
+  ? TDefaultAs
+  : TAsProp;
+
+export type TRenderProps<
+  TSlotProps extends {},
+  TAsProp extends SupportedAs,
+  TDefaultAs
+  > = TRestProps<TResolveAs<TAsProp, TDefaultAs>> & {
+    name: string;
+    slotProps: TSlotProps;
+    el?: HTMLElement | null;
+    visible?: boolean;
+    features?: Features;
+    as: TAsProp;
+    static?: boolean;
+    unmount?: boolean;
+    /**
+     * A list of actions to apply to the component's HTML element.
+     *
+     * Each action must take the form `[action]` or `[action, options]`:
+     *
+     * use={[[action1], [action2, action2Options], [action3]]}
+     */
+    use?: HTMLActionArray;
+    /**
+     * The class attribute for this component.
+     *
+     * In addition to a regular string, this may be a function that returns a string.
+     * In that case, the function will be passed this component's slot props as an argument,
+     * allowing you to conditionally apply classes. See the component's documentation for more.
+     */
+    class?: ((props: TSlotProps) => string) | string;
+    /**
+     * The style attribute for this component.
+     *
+     * In addition to a regular string, this may be a function that returns a string.
+     * In that case, the function will be passed this component's slot props as an argument,
+     * allowing you to conditionally apply styles. See the component's documentation for more.
+     */
+    style?: ((props: TSlotProps) => string) | string;
+  };
+
+export type TInternalProps = "name" | "slotProps" | "el" | "visible" | "features";
+
+export type TPassThroughProps<
+  TSlotProps extends {},
+  TAsProp extends SupportedAs,
+  TDefaultAs
+  > = Omit<
+    TRenderProps<TSlotProps, TAsProp, TDefaultAs>,
+    TInternalProps | "as" | "static" | "unmount"
+  > & {
+    /** The HTML element the component should render as */
+    as?: TAsProp;
+  };

--- a/src/lib/utils/Render.svelte
+++ b/src/lib/utils/Render.svelte
@@ -44,15 +44,36 @@
     TDefaultAs
   > = TRestProps<TResolveAs<TAsProp, TDefaultAs>> & {
     name: string;
-    as: TAsProp;
     slotProps: TSlotProps;
     el?: HTMLElement | null;
-    use?: HTMLActionArray;
     visible?: boolean;
     features?: Features;
+    as: TAsProp;
     static?: boolean;
     unmount?: boolean;
+    /**
+     * A list of actions to apply to the component's HTML element.
+     *
+     * Each action must take the form `[action]` or `[action, options]`:
+     *
+     * use={[[action1], [action2, action2Options], [action3]]}
+     */
+    use?: HTMLActionArray;
+    /**
+     * The class attribute for this component.
+     *
+     * In addition to a regular string, this may be a function that returns a string.
+     * In that case, the function will be passed this component's slot props as an argument,
+     * allowing you to conditionally apply classes. See the component's documentation for more.
+     */
     class?: ((props: TSlotProps) => string) | string;
+    /**
+     * The style attribute for this component.
+     *
+     * In addition to a regular string, this may be a function that returns a string.
+     * In that case, the function will be passed this component's slot props as an argument,
+     * allowing you to conditionally apply styles. See the component's documentation for more.
+     */
     style?: ((props: TSlotProps) => string) | string;
   };
 
@@ -66,6 +87,7 @@
     TRenderProps<TSlotProps, TAsProp, TDefaultAs>,
     TInternalProps | "as" | "static" | "unmount"
   > & {
+    /** The HTML element the component should render as */
     as?: TAsProp;
   };
 </script>

--- a/src/lib/utils/Render.svelte
+++ b/src/lib/utils/Render.svelte
@@ -1,101 +1,19 @@
 <script lang="ts" context="module">
-  import type { SupportedAs, SupportedElement } from "$lib/internal/elements";
+  import type { SupportedAs } from "$lib/internal/elements";
   import { getElementComponent } from "$lib/internal/elements";
   import { get_current_component } from "svelte/internal";
-
-  export enum Features {
-    /** No features at all */
-    None = 0,
-
-    /**
-     * When used, this will allow us to use one of the render strategies.
-     *
-     * **The render strategies are:**
-     *    - **Unmount**   _(Will unmount the component.)_
-     *    - **Hidden**    _(Will hide the component using the [hidden] attribute.)_
-     */
-    RenderStrategy = 1,
-
-    /**
-     * When used, this will allow the user of our component to be in control. This can be used when
-     * you want to transition based on some state.
-     */
-    Static = 2,
-  }
 
   export enum RenderStrategy {
     Unmount,
     Hidden,
   }
-
-  type TRestProps<T> = T extends SupportedElement
-    ? Omit<
-        svelte.JSX.HTMLAttributes<HTMLElementTagNameMap[T]>,
-        "class" | "style"
-      >
-    : {};
-
-  type TResolveAs<TAsProp, TDefaultAs> = SupportedAs extends TAsProp
-    ? TDefaultAs
-    : TAsProp;
-  type TRenderProps<
-    TSlotProps extends {},
-    TAsProp extends SupportedAs,
-    TDefaultAs
-  > = TRestProps<TResolveAs<TAsProp, TDefaultAs>> & {
-    name: string;
-    slotProps: TSlotProps;
-    el?: HTMLElement | null;
-    visible?: boolean;
-    features?: Features;
-    as: TAsProp;
-    static?: boolean;
-    unmount?: boolean;
-    /**
-     * A list of actions to apply to the component's HTML element.
-     *
-     * Each action must take the form `[action]` or `[action, options]`:
-     *
-     * use={[[action1], [action2, action2Options], [action3]]}
-     */
-    use?: HTMLActionArray;
-    /**
-     * The class attribute for this component.
-     *
-     * In addition to a regular string, this may be a function that returns a string.
-     * In that case, the function will be passed this component's slot props as an argument,
-     * allowing you to conditionally apply classes. See the component's documentation for more.
-     */
-    class?: ((props: TSlotProps) => string) | string;
-    /**
-     * The style attribute for this component.
-     *
-     * In addition to a regular string, this may be a function that returns a string.
-     * In that case, the function will be passed this component's slot props as an argument,
-     * allowing you to conditionally apply styles. See the component's documentation for more.
-     */
-    style?: ((props: TSlotProps) => string) | string;
-  };
-
-  type TInternalProps = "name" | "slotProps" | "el" | "visible" | "features";
-
-  export type TPassThroughProps<
-    TSlotProps extends {},
-    TAsProp extends SupportedAs,
-    TDefaultAs
-  > = Omit<
-    TRenderProps<TSlotProps, TAsProp, TDefaultAs>,
-    TInternalProps | "as" | "static" | "unmount"
-  > & {
-    /** The HTML element the component should render as */
-    as?: TAsProp;
-  };
 </script>
 
 <script lang="ts">
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
   import { forwardEventsBuilder } from "$lib/internal/forwardEventsBuilder";
   import type { SvelteComponent } from "svelte";
+  import { Features, type TRenderProps } from "$lib/types";
   const forwardEvents = forwardEventsBuilder(get_current_component());
 
   type TSlotProps = $$Generic<{}>;

--- a/src/lib/utils/Render.svelte
+++ b/src/lib/utils/Render.svelte
@@ -73,6 +73,7 @@
 <script lang="ts">
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
   import { forwardEventsBuilder } from "$lib/internal/forwardEventsBuilder";
+  import type { SvelteComponent } from "svelte";
   const forwardEvents = forwardEventsBuilder(get_current_component());
 
   type TSlotProps = $$Generic<{}>;
@@ -104,7 +105,9 @@
     throw new Error(`<${name}> did not provide an \`as\` value to <Render>`);
   }
 
-  let element = typeof as === "string" ? getElementComponent(as) : as;
+  // This type is a lie (could also be undefined) but there's a type error if we allow undefined
+  let element: typeof SvelteComponent =
+    typeof as === "string" ? getElementComponent(as) : as;
   if (!element) {
     throw new Error(
       `<${name}> has an invalid or unsupported \`as\` prop: ${as}`

--- a/src/lib/utils/Render.svelte
+++ b/src/lib/utils/Render.svelte
@@ -35,10 +35,14 @@
       >
     : {};
 
+  type TResolveAs<TAsProp, TDefaultAs> = SupportedAs extends TAsProp
+    ? TDefaultAs
+    : TAsProp;
   type TRenderProps<
     TSlotProps extends {},
-    TAsProp extends SupportedAs
-  > = TRestProps<TAsProp> & {
+    TAsProp extends SupportedAs,
+    TDefaultAs
+  > = TRestProps<TResolveAs<TAsProp, TDefaultAs>> & {
     name: string;
     as: TAsProp;
     slotProps: TSlotProps;
@@ -56,9 +60,10 @@
 
   export type TPassThroughProps<
     TSlotProps extends {},
-    TAsProp extends SupportedAs
+    TAsProp extends SupportedAs,
+    TDefaultAs
   > = Omit<
-    TRenderProps<TSlotProps, TAsProp>,
+    TRenderProps<TSlotProps, TAsProp, TDefaultAs>,
     TInternalProps | "as" | "static" | "unmount"
   > & {
     as?: TAsProp;
@@ -72,7 +77,7 @@
 
   type TSlotProps = $$Generic<{}>;
   type TAsProp = $$Generic<SupportedAs>;
-  type $$Props = TRenderProps<TSlotProps, TAsProp>;
+  type $$Props = TRenderProps<TSlotProps, TAsProp, TAsProp>;
 
   export let name: string;
   export let as: TAsProp;

--- a/src/lib/utils/Render.svelte
+++ b/src/lib/utils/Render.svelte
@@ -1,7 +1,7 @@
 <script lang="ts" context="module">
-  import type { SupportedElement } from "$lib/internal/elements";
+  import type { SupportedAs, SupportedElement } from "$lib/internal/elements";
   import { getElementComponent } from "$lib/internal/elements";
-  import { get_current_component, SvelteComponent } from "svelte/internal";
+  import { get_current_component } from "svelte/internal";
 
   export enum Features {
     /** No features at all */
@@ -27,21 +27,59 @@
     Unmount,
     Hidden,
   }
+
+  type TRestProps<T> = T extends SupportedElement
+    ? Omit<
+        svelte.JSX.HTMLAttributes<HTMLElementTagNameMap[T]>,
+        "class" | "style"
+      >
+    : {};
+
+  type TRenderProps<
+    TSlotProps extends {},
+    TAsProp extends SupportedAs
+  > = TRestProps<TAsProp> & {
+    name: string;
+    as: TAsProp;
+    slotProps: TSlotProps;
+    el?: HTMLElement | null;
+    use?: HTMLActionArray;
+    visible?: boolean;
+    features?: Features;
+    static?: boolean;
+    unmount?: boolean;
+    class?: ((props: TSlotProps) => string) | string;
+    style?: ((props: TSlotProps) => string) | string;
+  };
+
+  type TInternalProps = "name" | "slotProps" | "el" | "visible" | "features";
+
+  export type TPassThroughProps<
+    TSlotProps extends {},
+    TAsProp extends SupportedAs
+  > = Omit<
+    TRenderProps<TSlotProps, TAsProp>,
+    TInternalProps | "as" | "static" | "unmount"
+  > & {
+    as?: TAsProp;
+  };
 </script>
 
 <script lang="ts">
-  import type { ActionArray } from "$lib/hooks/use-actions";
+  import type { HTMLActionArray } from "$lib/hooks/use-actions";
   import { forwardEventsBuilder } from "$lib/internal/forwardEventsBuilder";
   const forwardEvents = forwardEventsBuilder(get_current_component());
 
   type TSlotProps = $$Generic<{}>;
+  type TAsProp = $$Generic<SupportedAs>;
+  type $$Props = TRenderProps<TSlotProps, TAsProp>;
 
   export let name: string;
-  export let as: SvelteComponent | SupportedElement;
+  export let as: TAsProp;
   export let slotProps: TSlotProps;
 
   export let el: HTMLElement | null = null;
-  export let use: ActionArray = [];
+  export let use: HTMLActionArray = [];
   export let visible = true;
   export let features: Features = Features.None;
   // The static and unmount props are only used in conjunction with the render strategies

--- a/src/routes/dialog/index.svelte
+++ b/src/routes/dialog/index.svelte
@@ -55,7 +55,7 @@
 {#if nested}
   <Nested on:close={() => (nested = false)} />
 {/if}
-<Transition show={isOpen} afterLeave={() => console.log("done")}>
+<Transition show={isOpen} on:afterLeave={() => console.log("done")}>
   <Dialog on:close={() => (isOpen = false)}>
     <div class="fixed z-10 inset-0 overflow-y-auto">
       <div

--- a/src/routes/docs/examples/radio-group.svelte
+++ b/src/routes/docs/examples/radio-group.svelte
@@ -36,7 +36,6 @@
       <div class="space-y-2">
         {#each plans as plan (plan.name)}
           <RadioGroupOption
-            key={plan.name}
             value={plan}
             class={({ active, checked }) =>
               `${

--- a/src/routes/listbox/_PeopleList.svelte
+++ b/src/routes/listbox/_PeopleList.svelte
@@ -75,7 +75,6 @@
           >
             {#each people as name (name)}
               <ListboxOption
-                key={name}
                 value={name}
                 class={({ active }) => {
                   return classNames(

--- a/src/routes/listbox/listbox-with-pure-tailwind.svelte
+++ b/src/routes/listbox/listbox-with-pure-tailwind.svelte
@@ -74,7 +74,6 @@
             >
               {#each people as name (name)}
                 <ListboxOption
-                  key={name}
                   value={name}
                   class={({ active }) => {
                     return classNames(

--- a/src/routes/tabs/tabs-with-pure-tailwind.svelte
+++ b/src/routes/tabs/tabs-with-pure-tailwind.svelte
@@ -56,7 +56,6 @@
     >
       {#each tabs as tab, tabIdx (tab.name)}
         <Tab
-          key={tab.name}
           disabled={tab.disabled}
           class={({ selected }) =>
             classNames(
@@ -85,7 +84,7 @@
 
     <TabPanels class="mt-4">
       {#each tabs as tab (tab.name)}
-        <TabPanel class="bg-white rounded-lg p-4 shadow" key={tab.name}>
+        <TabPanel class="bg-white rounded-lg p-4 shadow">
           {tab.content}
         </TabPanel>
       {/each}


### PR DESCRIPTION
This branch contains some big updates to TypeScript support by using the `$$Props` feature. This will:

* Make TS understand the types of `class` and `style` correctly when used as functions of their slot props
* Understand all HTML attribute props and reject unknown props that do not exist on the element, the same as HTML elements, which will make it much easier to eg convert React Tailwind UI code
* Add JSDoc comments to props, which will be visible in your editor.

Merging this is blocked by a bug in SvelteKit's packaging: see https://github.com/sveltejs/kit/issues/3783 I opened a PR for  a possible fix to the language tools https://github.com/sveltejs/language-tools/pull/1405 and depending on whether this or something else is merged, another (tiny) PR to Kit may be required. 