### PR TITLE
feat: Allow 'multiple' Listbox options

### DIFF
--- a/src/lib/components/listbox/Listbox.svelte
+++ b/src/lib/components/listbox/Listbox.svelte
@@ -66,7 +66,7 @@
     horizontal?: boolean;
     /** The selected value */
     value?: StateDefinition["value"];
-    /** Wether the `Listbox` should allow mutliple selections */
+    /** Whether the `Listbox` should allow mutliple selections */
     multiple?: boolean;
   };
 </script>

--- a/src/lib/components/listbox/Listbox.svelte
+++ b/src/lib/components/listbox/Listbox.svelte
@@ -3,6 +3,10 @@
     Open,
     Closed,
   }
+  export enum ValueMode {
+    Single,
+    Multi,
+  }
   export type ListboxOptionDataRef = {
     textValue: string;
     disabled: boolean;
@@ -14,6 +18,7 @@
     listboxState: ListboxStates;
     value: unknown;
     orientation: "vertical" | "horizontal";
+    mode: ValueMode;
 
     labelRef: Writable<HTMLLabelElement | null>;
     buttonRef: Writable<HTMLButtonElement | null>;
@@ -61,6 +66,8 @@
     horizontal?: boolean;
     /** The selected value */
     value?: StateDefinition["value"];
+    /** Wether the `Listbox` should allow mutliple selections */
+    multiple?: boolean;
   };
 </script>
 
@@ -89,6 +96,7 @@
   export let use: HTMLActionArray = [];
   export let disabled = false;
   export let horizontal = false;
+  export let multiple = false;
   export let value: StateDefinition["value"];
 
   /***** Events *****/
@@ -112,6 +120,9 @@
   let options: StateDefinition["options"] = [];
   let searchQuery: StateDefinition["searchQuery"] = "";
   let activeOptionIndex: StateDefinition["activeOptionIndex"] = null;
+  let mode: StateDefinition["mode"] = multiple
+    ? ValueMode.Multi
+    : ValueMode.Single;
 
   let api = writable<StateDefinition>({
     listboxState,
@@ -124,6 +135,7 @@
     activeOptionIndex,
     disabled,
     orientation,
+    mode,
     closeListbox() {
       if (disabled) return;
       if (listboxState === ListboxStates.Closed) return;
@@ -231,7 +243,25 @@
     },
     select(value: unknown) {
       if (disabled) return;
-      dispatch("change", value);
+      dispatch(
+        "change",
+        match(mode, {
+          [ValueMode.Single]: () => value,
+          [ValueMode.Multi]: () => {
+            let copy = ($api.value as unknown[]).slice();
+            let raw = value;
+
+            let idx = copy.indexOf(raw);
+            if (idx === -1) {
+              copy.push(raw);
+            } else {
+              copy.splice(idx, 1);
+            }
+
+            return copy;
+          },
+        })
+      );
     },
   });
   setContext(LISTBOX_CONTEXT_NAME, api);
@@ -256,6 +286,7 @@
       activeOptionIndex,
       disabled,
       orientation,
+      mode,
     };
   });
 

--- a/src/routes/docs/listbox.svx
+++ b/src/routes/docs/listbox.svx
@@ -99,6 +99,44 @@ You can use these states to conditionally apply whatever active/focus styles you
 </Listbox>
 ```
 
+## Multiple Values
+
+To allow selecting multiple values in your listbox, use the `multiple` prop and pass an array to `value` instead of a single option.
+
+```svelte
+<script>
+  import {
+    Listbox,
+    ListboxButton,
+    ListboxLabel,
+    ListboxOptions,
+    ListboxOption,
+  } from "@rgossiaux/svelte-headlessui";
+
+  const people = [
+    { id: 1, name: "Durward Reynolds" },
+    { id: 2, name: "Kenton Towne" },
+    { id: 3, name: "Therese Wunsch" },
+    { id: 4, name: "Benedict Kessler" },
+    { id: 5, name: "Katelyn Rohan" },
+  ];
+
+  let selectedPeople = [people[0], people[1]];
+</script>
+
+<Listbox value={selectedPeople} on:change={(e) => (selectedPeople = e.detail)} multiple>
+  <ListboxLabel>Assignee:</ListboxLabel>
+  <ListboxButton>{selectedPeople.map((person) => person.name).join(', ')}</ListboxButton>
+  <ListboxOptions>
+    {#each people as person (person.id)}
+      <ListboxOption value={person}>
+        {person.name}
+      </ListboxOption>
+    {/each}
+  </ListboxOptions>
+</Listbox>
+```
+
 ## Using a custom label
 
 By default, the `Listbox` will use the `<ListboxButton>` contents as the label for screenreaders. If you'd like more control over what is announced to assistive technologies, use the `ListboxLabel` component:


### PR DESCRIPTION
## Added
- `multiple` as a Listbox option allowing a multi-select
- Listbox example using `multiple`

## Note
I needed this for a project I'm migrating over to Svelte (from Vue), so I make a quick fork to implement the `multiple` option that HeadlessUI currently has (near 1:1 implementation).

I took a glance at #47, #57, and #63 where you mentioned doing a bit of a rework. If this PR won't work because of that, no worries.
