### PR TITLE
Error when styling tabs using Docs example

### DIFF
--- a/src/routes/docs/tabs.svx
+++ b/src/routes/docs/tabs.svx
@@ -58,7 +58,7 @@ To style the active `Tab`, you can use the `selected` slot prop that it provides
 
 <TabGroup>
   <TabList>
-    <Tab class={({selected}) => "tab-selected" : "tab-unselected"}>Tab 1</Tab>
+    <Tab class={({selected}) => selected ? "tab-selected" : "tab-unselected"}>Tab 1</Tab>
     <!-- ... -->
   </TabList>
   <TabPanels>


### PR DESCRIPTION
The existing example of styling tabs in the Docs `<Tab class={({selected}) => "tab-selected" : "tab-unselected"}>Tab 1</Tab>` throws this error `Expected } svelte(unexpected-token) Expected } js(-1)` at the `:` character

Fixed by changing it to `<Tab class={({selected}) => selected ? "tab-selected" : "tab-unselected"}>Tab 1</Tab>`