### PR TITLE
Support name prop for Switch,Listbox and RadioGroupOption

### DIFF
--- a/src/lib/components/description/Description.svelte
+++ b/src/lib/components/description/Description.svelte
@@ -26,7 +26,7 @@
 </script>
 
 <Render
-  name={"Description"}
+  componentName={"Description"}
   {...$$restProps}
   {as}
   {slotProps}

--- a/src/lib/components/dialog/Dialog.svelte
+++ b/src/lib/components/dialog/Dialog.svelte
@@ -300,7 +300,7 @@
               {as}
               {slotProps}
               use={[...use, forwardEvents]}
-              name={"Dialog"}
+              componentName={"Dialog"}
               bind:el={internalDialogRef}
               aria-describedby={describedby}
               on:click={handleClick}

--- a/src/lib/components/dialog/DialogOverlay.svelte
+++ b/src/lib/components/dialog/DialogOverlay.svelte
@@ -51,7 +51,7 @@
   {as}
   {slotProps}
   use={[...use, forwardEvents]}
-  name={"DialogOverlay"}
+  componentName={"DialogOverlay"}
   on:click={handleClick}
 >
   <slot {...slotProps} />

--- a/src/lib/components/dialog/DialogTitle.svelte
+++ b/src/lib/components/dialog/DialogTitle.svelte
@@ -46,7 +46,7 @@
   {as}
   {slotProps}
   use={[...use, forwardEvents]}
-  name={"DialogTitle"}
+  componentName={"DialogTitle"}
 >
   <slot {...slotProps} />
 </Render>

--- a/src/lib/components/disclosure/Disclosure.svelte
+++ b/src/lib/components/disclosure/Disclosure.svelte
@@ -146,7 +146,7 @@
   {as}
   {slotProps}
   use={[...use, forwardEvents]}
-  name={"Disclosure"}
+  componentName={"Disclosure"}
 >
   <slot {...slotProps} />
 </Render>

--- a/src/lib/components/disclosure/DisclosureButton.svelte
+++ b/src/lib/components/disclosure/DisclosureButton.svelte
@@ -118,7 +118,7 @@
     {as}
     {slotProps}
     use={[...use, forwardEvents]}
-    name={"DisclosureButton"}
+    componentName={"DisclosureButton"}
     bind:el={$ourStore}
     on:click={handleClick}
     on:keydown={handleKeyDown}
@@ -131,7 +131,7 @@
     {as}
     {slotProps}
     use={[...use, forwardEvents]}
-    name={"DisclosureButton"}
+    componentName={"DisclosureButton"}
     bind:el={$ourStore}
     on:click={handleClick}
     on:keydown={handleKeyDown}

--- a/src/lib/components/disclosure/DisclosurePanel.svelte
+++ b/src/lib/components/disclosure/DisclosurePanel.svelte
@@ -62,7 +62,7 @@
   {as}
   {slotProps}
   use={[...use, forwardEvents]}
-  name={"DisclosurePanel"}
+  componentName={"DisclosurePanel"}
   bind:el={$panelStore}
   {visible}
   features={Features.RenderStrategy | Features.Static}

--- a/src/lib/components/label/Label.svelte
+++ b/src/lib/components/label/Label.svelte
@@ -32,7 +32,7 @@
 
 <Render
   {...allProps}
-  name={"Label"}
+  componentName={"Label"}
   {as}
   {slotProps}
   use={[...use, forwardEvents]}

--- a/src/lib/components/listbox/Listbox.svelte
+++ b/src/lib/components/listbox/Listbox.svelte
@@ -23,6 +23,7 @@
     options: { id: string; dataRef: ListboxOptionDataRef }[];
     searchQuery: string;
     activeOptionIndex: number | null;
+    name: string;
 
     // State mutators
     closeListbox(): void;
@@ -61,6 +62,8 @@
     horizontal?: boolean;
     /** The selected value */
     value?: StateDefinition["value"];
+    /** The name used when using this component inside a form. */
+    name?: string;
   };
 </script>
 
@@ -90,6 +93,7 @@
   export let disabled = false;
   export let horizontal = false;
   export let value: StateDefinition["value"];
+  export let name: string | null = null;
 
   /***** Events *****/
   const forwardEvents = forwardEventsBuilder(get_current_component(), [
@@ -124,6 +128,7 @@
     activeOptionIndex,
     disabled,
     orientation,
+    name,
     closeListbox() {
       if (disabled) return;
       if (listboxState === ListboxStates.Closed) return;
@@ -281,7 +286,7 @@
   {as}
   {slotProps}
   use={[...use, forwardEvents]}
-  name={"Listbox"}
+  componentName={"Listbox"}
 >
   <slot {...slotProps} />
 </Render>

--- a/src/lib/components/listbox/ListboxButton.svelte
+++ b/src/lib/components/listbox/ListboxButton.svelte
@@ -97,6 +97,7 @@
       : $api.listboxState === ListboxStates.Open,
     "aria-labelledby": $labelRef ? [$labelRef?.id, id].join(" ") : undefined,
     disabled: $api.disabled === true ? true : undefined,
+    name: $api.name,
   };
 
   $: slotProps = {
@@ -111,7 +112,7 @@
   {as}
   {slotProps}
   use={[...use, forwardEvents]}
-  name={"ListboxButton"}
+  componentName={"ListboxButton"}
   bind:el={$buttonRef}
   on:click={handleClick}
   on:keydown={handleKeyDown}

--- a/src/lib/components/listbox/ListboxLabel.svelte
+++ b/src/lib/components/listbox/ListboxLabel.svelte
@@ -48,7 +48,7 @@
   {as}
   {slotProps}
   use={[...use, forwardEvents]}
-  name={"ListboxLabel"}
+  componentName={"ListboxLabel"}
   bind:el={$labelRef}
   on:click={handleClick}
 >

--- a/src/lib/components/listbox/ListboxOption.svelte
+++ b/src/lib/components/listbox/ListboxOption.svelte
@@ -132,7 +132,7 @@
   {as}
   {slotProps}
   use={[...use, forwardEvents]}
-  name={"ListboxOption"}
+  componentName={"ListboxOption"}
   on:click={handleClick}
   on:focus={handleFocus}
   on:pointermove={handleMove}

--- a/src/lib/components/listbox/ListboxOptions.svelte
+++ b/src/lib/components/listbox/ListboxOptions.svelte
@@ -146,7 +146,7 @@
   {as}
   {slotProps}
   use={[...use, forwardEvents]}
-  name={"ListboxOptions"}
+  componentName={"ListboxOptions"}
   bind:el={$optionsRef}
   on:keydown={handleKeyDown}
   {visible}

--- a/src/lib/components/listbox/listbox.test.ts
+++ b/src/lib/components/listbox/listbox.test.ts
@@ -178,6 +178,28 @@ describe('Rendering', () => {
         assertListbox({ state: ListboxState.InvisibleUnmounted })
       })
     )
+    
+    describe("`name` attribute", () => {
+      it('should set the `name` to "listbox-name"', async () => {
+        render(svelte`
+          <Listbox name="listbox-name" value={null} on:change={console.log}>
+            <ListboxButton>Trigger</ListboxButton>
+          </Listbox>
+        `);
+
+        expect(getListboxButton()).toHaveAttribute('name', 'listbox-name')
+      })
+
+      it('should not set the name if no "name" prop is passed', async () => {
+        render(svelte`
+          <Listbox value={null} on:change={console.log}>
+            <ListboxButton as="div">Trigger</ListboxButton>
+          </Listbox>
+        `);
+
+        expect(getListboxButton()).not.toHaveAttribute('name')
+      })
+    }) 
   })
 
   describe('ListboxLabel', () => {

--- a/src/lib/components/menu/Menu.svelte
+++ b/src/lib/components/menu/Menu.svelte
@@ -219,7 +219,7 @@
   use={[...use, forwardEvents]}
   {as}
   {slotProps}
-  name={"Menu"}
+  componentName={"Menu"}
 >
   <slot {...slotProps} />
 </Render>

--- a/src/lib/components/menu/MenuButton.svelte
+++ b/src/lib/components/menu/MenuButton.svelte
@@ -112,7 +112,7 @@
   {as}
   {slotProps}
   use={[...use, forwardEvents]}
-  name={"MenuButton"}
+  componentName={"MenuButton"}
   bind:el={$buttonStore}
   on:click={handleClick}
   on:keydown={handleKeyDown}

--- a/src/lib/components/menu/MenuItem.svelte
+++ b/src/lib/components/menu/MenuItem.svelte
@@ -107,7 +107,7 @@
   use={[...use, forwardEvents]}
   {as}
   {slotProps}
-  name={"MenuItem"}
+  componentName={"MenuItem"}
   bind:el={elementRef}
   on:click={handleClick}
   on:focus={handleFocus}

--- a/src/lib/components/menu/MenuItems.svelte
+++ b/src/lib/components/menu/MenuItems.svelte
@@ -167,7 +167,7 @@
   {slotProps}
   use={[...use, forwardEvents]}
   bind:el={$itemsStore}
-  name={"MenuItems"}
+  componentName={"MenuItems"}
   on:keydown={handleKeyDown}
   on:keyup={handleKeyUp}
   {visible}

--- a/src/lib/components/popover/Popover.svelte
+++ b/src/lib/components/popover/Popover.svelte
@@ -191,7 +191,7 @@
   {as}
   {slotProps}
   use={[...use, forwardEvents]}
-  name={"Popover"}
+  componentName={"Popover"}
 >
   <slot {...slotProps} />
 </Render>

--- a/src/lib/components/popover/PopoverButton.svelte
+++ b/src/lib/components/popover/PopoverButton.svelte
@@ -211,7 +211,7 @@
   {as}
   {slotProps}
   use={[...use, forwardEvents]}
-  name={"PopoverButton"}
+  componentName={"PopoverButton"}
   bind:el={$ourStore}
   on:click={handleClick}
   on:keydown={handleKeyDown}

--- a/src/lib/components/popover/PopoverGroup.svelte
+++ b/src/lib/components/popover/PopoverGroup.svelte
@@ -87,7 +87,7 @@
   {as}
   use={[...use, forwardEvents]}
   {slotProps}
-  name={"PopoverGroup"}
+  componentName={"PopoverGroup"}
   bind:el={groupRef}
 >
   <slot {...slotProps} />

--- a/src/lib/components/popover/PopoverOverlay.svelte
+++ b/src/lib/components/popover/PopoverOverlay.svelte
@@ -52,7 +52,7 @@
   {as}
   {slotProps}
   use={[...use, forwardEvents]}
-  name={"PopoverOverlay"}
+  componentName={"PopoverOverlay"}
   on:click={handleClick}
   aria-hidden
   {visible}

--- a/src/lib/components/popover/PopoverPanel.svelte
+++ b/src/lib/components/popover/PopoverPanel.svelte
@@ -165,7 +165,7 @@
   {as}
   {slotProps}
   use={[...use, forwardEvents]}
-  name={"PopoverPanel"}
+  componentName={"PopoverPanel"}
   bind:el={$panelStore}
   on:keydown={handleKeydown}
   {visible}

--- a/src/lib/components/radio-group/RadioGroup.svelte
+++ b/src/lib/components/radio-group/RadioGroup.svelte
@@ -228,7 +228,7 @@
       {as}
       use={[...use, forwardEvents]}
       {slotProps}
-      name={"RadioGroup"}
+      componentName={"RadioGroup"}
       bind:el={radioGroupRef}
       aria-labelledby={labelledby}
       aria-describedby={describedby}

--- a/src/lib/components/radio-group/RadioGroupOption.svelte
+++ b/src/lib/components/radio-group/RadioGroupOption.svelte
@@ -10,6 +10,8 @@
     value: unknown;
     /** Whether the `RadioGroupOption` is disabled */
     disabled?: boolean;
+    /** The name used when using this component inside a form. */
+    name?: string;
   };
 </script>
 
@@ -35,6 +37,7 @@
   export let use: HTMLActionArray = [];
   export let value: unknown;
   export let disabled: boolean = false;
+  export let name: string | null = null;
 
   /***** Events *****/
   const forwardEvents = forwardEventsBuilder(get_current_component());
@@ -88,6 +91,7 @@
     "aria-checked": checked ? ("true" as const) : ("false" as const),
     "aria-disabled": isDisabled ? true : undefined,
     tabIndex: tabIndex,
+    name,
   };
 
   $: slotProps = {
@@ -104,7 +108,7 @@
       {as}
       {slotProps}
       use={[...use, forwardEvents]}
-      name={"RadioGroupOption"}
+      componentName={"RadioGroupOption"}
       bind:el={optionRef}
       aria-labelledby={labelledby}
       aria-describedby={describedby}

--- a/src/lib/components/radio-group/radio-group.test.ts
+++ b/src/lib/components/radio-group/radio-group.test.ts
@@ -771,3 +771,37 @@ describe('Mouse interactions', () => {
     expect(changeFn).toHaveBeenCalledTimes(1)
   })
 })
+
+describe("`name` attribute", () => {
+  it('should set the `name` to "radio-option-name"', async () => {
+    render(svelte`
+        <RadioGroup value={undefined} on:change={console.log}>
+          <RadioGroupLabel>Pizza Delivery</RadioGroupLabel>
+          <RadioGroupOption name="radio-option-name" value="pickup">Pickup</RadioGroupOption>
+          <RadioGroupOption name="radio-option-name" value="home-delivery">Home delivery</RadioGroupOption>
+          <RadioGroupOption name="radio-option-name" value="dine-in">Dine in</RadioGroupOption>
+        </RadioGroup>
+    `);
+
+    let options = getRadioGroupOptions();    
+    for (let option of options)
+      expect(option).toHaveAttribute("name", "radio-option-name");
+
+  });
+
+  it('should not set the name if no "name" prop is passed', async () => {
+    render(svelte`
+        <RadioGroup value={undefined} on:change={console.log}>
+          <RadioGroupLabel>Pizza Delivery</RadioGroupLabel>
+          <RadioGroupOption value="pickup">Pickup</RadioGroupOption>
+          <RadioGroupOption value="home-delivery">Home delivery</RadioGroupOption>
+          <RadioGroupOption value="dine-in">Dine in</RadioGroupOption>
+        </RadioGroup>
+    `);
+
+    let options = getRadioGroupOptions();    
+    for (let option of options)
+      expect(option).not.toHaveAttribute("name");    
+      
+  });
+});

--- a/src/lib/components/switch/Switch.svelte
+++ b/src/lib/components/switch/Switch.svelte
@@ -5,6 +5,8 @@
   > = TPassThroughProps<TSlotProps, TAsProp, "button"> & {
     /** Whether the switch is checked */
     checked: boolean;
+    /** The name used when using this component inside a form. */
+    name?: string;
   };
 </script>
 
@@ -30,6 +32,7 @@
   export let as: SupportedAs = "button";
   export let use: HTMLActionArray = [];
   export let checked = false;
+  export let name: string | null = null;
 
   /***** Events *****/
   const forwardEvents = forwardEventsBuilder(get_current_component(), [
@@ -73,6 +76,7 @@
     role: "switch",
     type: resolveButtonType({ type: $$props.type, as }, $switchStore),
     tabIndex: 0,
+    name,
     "aria-checked": checked,
     "aria-labelledby": $labelContext?.labelIds,
     "aria-describedby": $descriptionContext?.descriptionIds,
@@ -88,7 +92,7 @@
     {as}
     {slotProps}
     use={[...use, forwardEvents]}
-    name={"Switch"}
+    componentName={"Switch"}
     bind:el={$switchStore}
     on:click={handleClick}
     on:keyup={handleKeyUp}
@@ -102,7 +106,7 @@
     {as}
     {slotProps}
     use={[...use, forwardEvents]}
-    name={"Switch"}
+    componentName={"Switch"}
     on:click={handleClick}
     on:keyup={handleKeyUp}
     on:keypress={handleKeyPress}

--- a/src/lib/components/switch/SwitchGroup.svelte
+++ b/src/lib/components/switch/SwitchGroup.svelte
@@ -59,7 +59,7 @@
   {as}
   use={[...use, forwardEvents]}
   {slotProps}
-  name={"SwitchGroup"}
+  componentName={"SwitchGroup"}
 >
   <DescriptionProvider name="SwitchDescription">
     <LabelProvider name="SwitchLabel" {onClick}>

--- a/src/lib/components/switch/switch.test.ts
+++ b/src/lib/components/switch/switch.test.ts
@@ -89,6 +89,24 @@ describe("Rendering", () => {
       expect(getSwitch()).not.toHaveAttribute("type");
     });
   });
+
+  describe("`name` attribute", () => {
+    it('should set the `name` to "switch-name"', async () => {
+      render(svelte`
+        <Switch name="switch-name" checked={false} on:change={console.log} as={"div"}>Trigger</Switch>
+      `);
+
+      expect(getSwitch()).toHaveAttribute("name", "switch-name");
+    });
+
+    it('should not set the name if no "name" prop is passed', async () => {
+      render(svelte`
+        <Switch checked={false} on:change={console.log} as={"div"}>Trigger</Switch>
+      `);
+
+      expect(getSwitch()).not.toHaveAttribute("name");
+    });
+  });
 });
 
 describe("Render composition", () => {

--- a/src/lib/components/tabs/Tab.svelte
+++ b/src/lib/components/tabs/Tab.svelte
@@ -126,7 +126,7 @@
   {as}
   {slotProps}
   use={[...use, forwardEvents]}
-  name={"Tab"}
+  componentName={"Tab"}
   bind:el={tabRef}
   on:keydown={handleKeyDown}
   on:click={handleSelection}

--- a/src/lib/components/tabs/TabGroup.svelte
+++ b/src/lib/components/tabs/TabGroup.svelte
@@ -200,7 +200,7 @@
   {as}
   {slotProps}
   use={[...use, forwardEvents]}
-  name={"TabGroup"}
+  componentName={"TabGroup"}
 >
   <slot {...slotProps} />
 </Render>

--- a/src/lib/components/tabs/TabList.svelte
+++ b/src/lib/components/tabs/TabList.svelte
@@ -42,7 +42,7 @@
   {slotProps}
   bind:el={$listRef}
   use={[...use, forwardEvents]}
-  name={"TabList"}
+  componentName={"TabList"}
 >
   <slot {...slotProps} />
 </Render>

--- a/src/lib/components/tabs/TabPanel.svelte
+++ b/src/lib/components/tabs/TabPanel.svelte
@@ -60,7 +60,7 @@
   {...{ ...$$restProps, ...propsWeControl }}
   {as}
   use={[...use, forwardEvents]}
-  name={"TabPanel"}
+  componentName={"TabPanel"}
   {slotProps}
   bind:el={$elementRef}
   visible={selected}

--- a/src/lib/components/tabs/TabPanels.svelte
+++ b/src/lib/components/tabs/TabPanels.svelte
@@ -34,7 +34,7 @@
   {as}
   {slotProps}
   use={[...use, forwardEvents]}
-  name={"TabPanels"}
+  componentName={"TabPanels"}
 >
   <slot {...slotProps} />
 </Render>

--- a/src/lib/components/transitions/TransitionChild.svelte
+++ b/src/lib/components/transitions/TransitionChild.svelte
@@ -241,7 +241,7 @@
   {as}
   use={[...use, forwardEvents]}
   slotProps={{}}
-  name={"TransitionChild"}
+  componentName={"TransitionChild"}
   bind:el={container}
   class={classes}
   visible={state === TreeStates.Visible}

--- a/src/lib/utils/Render.svelte
+++ b/src/lib/utils/Render.svelte
@@ -18,7 +18,7 @@
   type TAsProp = $$Generic<SupportedAs>;
   type $$Props = TRenderProps<TSlotProps, TAsProp, TAsProp>;
 
-  export let name: string;
+  export let componentName: string;
   export let as: TAsProp;
   export let slotProps: TSlotProps;
 
@@ -40,12 +40,14 @@
     undefined;
 
   if (!as) {
-    throw new Error(`<${name}> did not provide an \`as\` value to <Render>`);
+    throw new Error(
+      `<${componentName}> did not provide an \`as\` value to <Render>`
+    );
   }
 
   if (!isValidElement(as)) {
     throw new Error(
-      `<${name}> has an invalid or unsupported \`as\` prop: ${as}`
+      `<${componentName}> has an invalid or unsupported \`as\` prop: ${as}`
     );
   }
 

--- a/src/routes/docs/listbox.svx
+++ b/src/routes/docs/listbox.svx
@@ -490,6 +490,7 @@ The main listbox component.
 | `disabled`   | `false` | `boolean` | Whether the entire `Listbox` and its children should be disabled                   |
 | `horizontal` | `false` | `boolean` | Whether the entire `Listbox` should be oriented horizontally instead of vertically |
 | `value`      | --      | `T`       | The selected value                                                                 |
+| `name`       | --      | `string`  | The name used when using this component inside a form.                             |
 
 | Slot prop  | Type      | Description                            |
 | ---------- | --------- | -------------------------------------- |

--- a/src/routes/docs/radio-group.svx
+++ b/src/routes/docs/radio-group.svx
@@ -200,6 +200,7 @@ The wrapper component for each selectable option.
 | `as`       | `div`   | `string`           | The element the `RadioGroupOption` should render as                                                         |
 | `disabled` | `false` | `boolean`          | Whether the `RadioGroupOption` is disabled                                                                  |
 | `value`    | --      | `T` \| `undefined` | The value of the `RadioGroupOption`; the type should match the type of the `value` prop in the `RadioGroup` |
+| `name`     | --      | `string`           | The name used when using this component inside a form.                                                      |
 
 | Slot prop  | Type      | Description                                                |
 | ---------- | --------- | ---------------------------------------------------------- |

--- a/src/routes/docs/switch.svx
+++ b/src/routes/docs/switch.svx
@@ -274,10 +274,12 @@ For a full reference on all accessibility features implemented in `Switch`, see 
 
 The main switch component.
 
-| Prop      | Default  | Type      | Description                               |
-| --------- | -------- | --------- | ----------------------------------------- |
-| `as`      | `button` | `string`  | The element the `Switch` should render as |
-| `checked` | `false`  | `boolean` | Whether the switch is checked             |
+| Prop      | Default  | Type      | Description                                            |
+| --------- | -------- | --------- | -------------------------------------------------------|
+| `as`      | `button` | `string`  | The element the `Switch` should render as              |
+| `checked` | `false`  | `boolean` | Whether the switch is checked                          |
+| `name`    | --       | `string`  | The name used when using this component inside a form. |
+
 
 | Slot prop | Type      | Description                   |
 | --------- | --------- | ----------------------------- |


### PR DESCRIPTION
Add support for name prop to match HeadlessUI
Rename `name` prop in Render component to `componentName` to avoid conflit with `...$$restProps` Add tests to Switch,Listbox and RadioGroupOption to check for name attribute
Fixes #111 