### PR TITLE
Combobox component

### DIFF
--- a/src/lib/components/combobox/Combobox.svelte
+++ b/src/lib/components/combobox/Combobox.svelte
@@ -1,0 +1,522 @@
+<script lang="ts" context="module">
+  export enum ComboboxStates {
+    Open,
+    Closed,
+  }
+
+  export enum ValueMode {
+    Single,
+    Multi,
+  }
+
+  export enum ActivationTrigger {
+    Pointer,
+    Other,
+  }
+
+  export type ComboboxOptionData = {
+    disabled: boolean;
+    value: unknown;
+    domRef: Writable<HTMLElement | null>;
+  };
+
+  type StateDefinition = {
+    // State
+    comboboxState: ComboboxStates;
+    value: unknown;
+
+    mode: ValueMode;
+    nullable: boolean;
+
+    compare: (a: unknown, z: unknown) => boolean;
+
+    optionsPropsRef: Writable<{ static: boolean; hold: boolean }>;
+
+    labelRef: Writable<HTMLLabelElement | null>;
+    inputRef: Writable<HTMLInputElement | null>;
+    buttonRef: Writable<HTMLButtonElement | null>;
+    optionsRef: Writable<HTMLDivElement | null>;
+
+    disabled: boolean;
+    options: { id: string; dataRef: ComboboxOptionData }[];
+    activeOptionIndex: number | null;
+    activationTrigger: ActivationTrigger;
+
+    // State mutators
+    closeCombobox(): void;
+    openCombobox(): void;
+    goToOption(focus: Focus, id?: string, trigger?: ActivationTrigger): void;
+    change(value: unknown): void;
+    selectOption(id: string): void;
+    selectActiveOption(): void;
+    registerOption(id: string, dataRef: ComboboxOptionData): void;
+    unregisterOption(id: string): void;
+    //select(value: unknown): void;
+  };
+
+  const COMBOBOX_CONTEXT_NAME = "headlessui-combobox-context";
+
+  export function useComboboxContext(
+    component: string
+  ): Readable<StateDefinition> {
+    let context: Writable<StateDefinition> | undefined = getContext(
+      COMBOBOX_CONTEXT_NAME
+    );
+
+    if (context === undefined) {
+      throw new Error(
+        `<${component} /> is missing a parent <Combobox /> component.`
+      );
+    }
+
+    return context;
+  }
+
+  export function defaultComparator<T>(a: T, z: T): boolean {
+    return a === z;
+  }
+
+  type TComboboxProps<
+    TSlotProps extends {},
+    TAsProp extends SupportedAs
+  > = TPassThroughProps<TSlotProps, TAsProp, "div"> & {
+    /** Whether the entire `Combobox` and its children should be disabled */
+    disabled?: boolean;
+    /** The selected value */
+    value?: StateDefinition["value"];
+    /** The default value when using as an uncontrolled component. */
+    defaultValue?: StateDefinition["value"];
+    /** The name used when using this component inside a form. */
+    name?: string;
+    /** Use this to compare objects by a particular field, or pass your own comparison function for complete control over how objects are compared. */
+    by?: string | Function;
+    /** Whether you can clear the combobox or not. */
+    nullable?: boolean;
+    /** Whether multiple options can be selected or not. */
+    multiple?: boolean;
+  };
+</script>
+
+<script lang="ts">
+  import { get, writable, type Readable, type Writable } from "svelte/store";
+
+  import type { HTMLActionArray } from "$lib/hooks/use-actions";
+  import { useControllable } from "$lib/hooks/use-controllable";
+  import type { SupportedAs } from "$lib/internal/elements";
+  import { forwardEventsBuilder } from "$lib/internal/forwardEventsBuilder";
+  import Hidden, { Features as HiddenFeatures } from "$lib/internal/Hidden.svelte";
+  import { State, useOpenClosedProvider } from "$lib/internal/open-closed";
+  import type { TPassThroughProps } from "$lib/types";
+  import { calculateActiveIndex, Focus } from "$lib/utils/calculate-active-index";
+  import { sortByDomNode } from "$lib/utils/focus-management";
+  import { objectToFormEntries } from "$lib/utils/form";
+  import { match } from "$lib/utils/match";
+  import Render from "$lib/utils/Render.svelte";
+  import { getContext } from "svelte";
+  import {
+    createEventDispatcher,
+    get_current_component,
+    setContext
+  } from "svelte/internal";
+
+  /***** Props *****/
+  type TAsProp = $$Generic<SupportedAs>;
+  type $$Props = TComboboxProps<typeof slotProps, TAsProp>;
+
+  export let as: SupportedAs = "div";
+  export let use: HTMLActionArray = [];
+  export let by: string | Function = defaultComparator;
+  export let value: StateDefinition["value"];
+  export let defaultValue: unknown | null = null;
+  export let name: string | null = null;
+  export let nullable: StateDefinition["nullable"] = false;
+  export let multiple: boolean = false;
+  export let disabled = false;
+
+  /***** Events *****/
+  const forwardEvents = forwardEventsBuilder(get_current_component(), [
+    "change",
+  ]);
+
+  const dispatch = createEventDispatcher<{
+    change: any;
+  }>();
+
+  /***** Component *****/
+  let comboboxState: StateDefinition["comboboxState"] = ComboboxStates.Closed;
+  let labelRef: StateDefinition["labelRef"] = writable(null);
+  let inputRef: StateDefinition["inputRef"] = writable(null);
+  let buttonRef: StateDefinition["buttonRef"] = writable(null);
+  let optionsRef: StateDefinition["optionsRef"] = writable(null);
+  let optionsPropsRef: StateDefinition["optionsPropsRef"] = writable({
+    static: false,
+    hold: false,
+  });
+  let options: StateDefinition["options"] = [];
+  let activeOptionIndex: StateDefinition["activeOptionIndex"] = null;
+  let activationTrigger: StateDefinition["activationTrigger"] =
+    ActivationTrigger.Other;
+  let mode: StateDefinition["mode"] = multiple
+    ? ValueMode.Multi
+    : ValueMode.Single;
+  let defaultToFirstOption = false;
+
+  function adjustOrderedState(
+      adjustment: (
+        options: StateDefinition['options']
+      ) => StateDefinition['options'] = (i) => i
+    ) {      
+      let currentActiveOption =
+        activeOptionIndex !== null ? options[activeOptionIndex] : null
+
+      let sortedOptions = sortByDomNode(adjustment(options.slice()), (option) => {
+        return get(option.dataRef.domRef)
+    })
+
+      // If we inserted an option before the current active option then the active option index
+      // would be wrong. To fix this, we will re-lookup the correct index.
+      let adjustedActiveOptionIndex = currentActiveOption
+        ? sortedOptions.indexOf(currentActiveOption)
+        : null
+
+      // Reset to `null` in case the currentActiveOption was removed.
+      if (adjustedActiveOptionIndex === -1) {
+        adjustedActiveOptionIndex = null
+      }
+      
+      return {
+        options: sortedOptions,
+        activeOptionIndex: adjustedActiveOptionIndex,
+      }
+    }
+
+    // Reactive activeOptionIndex
+    $: {
+      if (
+        defaultToFirstOption &&
+        activeOptionIndex === null &&
+        options.length > 0
+      ) {
+        let localActiveOptionIndex = options.findIndex(
+          (option) => !option.dataRef.disabled
+        );
+        if (localActiveOptionIndex !== -1) {
+          activeOptionIndex = localActiveOptionIndex;
+        }
+      }
+
+      activeOptionIndex = activeOptionIndex
+    }
+  
+  let isControlled = value !== undefined;  
+  value = isControlled ? value : defaultValue  
+
+  let oldValue:unknown
+  function valueChanged<T>(controlledValue: T | undefined, internalValue?: T) {  
+
+    let isControlled = value !== undefined;
+    value = (isControlled ? controlledValue : internalValue)!;    
+
+    if (oldValue == value)
+      return
+    
+    if (isControlled) {
+      dispatch("change", value);
+    } else {
+      defaultValue = value;
+      dispatch("change", value);
+    }
+
+    oldValue = value
+  }
+
+  let [controlledValue, theirOnChange] = useControllable<any>(
+    value,
+    (value: unknown) => {
+      valueChanged(value, defaultValue)            
+      //dispatch("change", value)      
+    },
+    defaultValue
+  )
+
+  let api = writable<StateDefinition>({
+    comboboxState,
+    value,
+    mode,
+    compare(a: any, z: any) {
+      if (typeof by === "string") {
+        let property = by as unknown as any;
+        return a?.[property] === z?.[property];
+      }
+      return by(a, z);
+    },
+    nullable,
+    inputRef,
+    labelRef,
+    buttonRef,
+    optionsRef,
+    disabled: disabled,
+    options,
+    change(value: unknown) {       
+      //dispatch("change", value);
+      theirOnChange(value)
+    },
+    activeOptionIndex,    
+    activationTrigger,
+    optionsPropsRef,
+    closeCombobox() {
+      defaultToFirstOption = false;
+
+      if (disabled) return;
+      if (comboboxState === ComboboxStates.Closed) return;
+      comboboxState = ComboboxStates.Closed;
+      activeOptionIndex = null;
+    },
+    openCombobox() {
+      defaultToFirstOption = true;
+
+      if (disabled) return;
+      if (comboboxState === ComboboxStates.Open) return;  
+      
+      // Check if we have a selected value that we can make active.
+      let optionIdx = options.findIndex((option) => {
+        let optionValue = option.dataRef.value;
+        let selected = match(mode, {
+          [ValueMode.Single]: () => $api.compare($api.value, optionValue),
+          [ValueMode.Multi]: () =>
+            ($api.value as unknown[]).some((value) =>
+              $api.compare(value, optionValue)
+            ),
+        });
+
+        return selected;
+      });      
+
+      if (optionIdx !== -1) {
+        activeOptionIndex = optionIdx;
+      }
+
+      comboboxState = ComboboxStates.Open;
+    },
+    goToOption(focus: Focus, id?: string, trigger?: ActivationTrigger) {
+      defaultToFirstOption = false;
+
+      if (disabled) return;
+      if (
+        optionsRef &&
+        !$optionsPropsRef.static &&
+        comboboxState === ComboboxStates.Closed
+      ) {
+        return;
+      }
+
+      let adjustedState = adjustOrderedState();
+
+      // It's possible that the activeOptionIndex is set to `null` internally, but
+      // this means that we will fallback to the first non-disabled option by default.
+      // We have to take this into account.
+      if (adjustedState.activeOptionIndex === null) {
+        let localActiveOptionIndex = adjustedState.options.findIndex(
+          (option) => !option.dataRef.disabled
+        );
+
+        if (localActiveOptionIndex !== -1) {
+          adjustedState.activeOptionIndex = localActiveOptionIndex;
+        }
+      }
+
+      let nextActiveOptionIndex = calculateActiveIndex(
+        focus === Focus.Specific
+          ? { focus: Focus.Specific, id: id! }
+          : { focus: focus as Exclude<Focus, Focus.Specific> },
+        {
+          resolveItems: () => adjustedState.options,
+          resolveActiveIndex: () => adjustedState.activeOptionIndex,
+          resolveId: (option) => option.id,
+          resolveDisabled: (option) => option.dataRef.disabled,
+        }
+      );
+
+      activeOptionIndex = nextActiveOptionIndex;
+      activationTrigger = trigger ?? ActivationTrigger.Other;
+      options = adjustedState.options;
+    },
+    selectOption(id: string) {         
+      let option = options.find((item) => item.id === id);
+      if (!option) return;
+
+      let { dataRef } = option;
+      theirOnChange(        
+        match(mode, {
+          [ValueMode.Single]: () => {             
+            return dataRef.value
+          },
+          [ValueMode.Multi]: () => {
+            let copy = ($api.value as unknown[]).slice();
+            let raw = dataRef.value;
+
+            let idx = copy.findIndex((value) => $api.compare(raw, value))            
+            if (idx === -1) {
+              copy.push(raw);
+            } else {
+              copy.splice(idx, 1);
+            }            
+            return copy;
+          },
+        })
+      );      
+    },
+    selectActiveOption() {
+      if ($api.activeOptionIndex === null) return;
+
+      let { dataRef, id } = options[$api.activeOptionIndex];
+      theirOnChange(        
+        match(mode, {
+          [ValueMode.Single]: () => dataRef.value,
+          [ValueMode.Multi]: () => {
+            let copy = ($api.value as unknown[]).slice();
+            let raw = dataRef.value;
+
+            let idx = copy.findIndex((value) => $api.compare(raw, value))            
+            if (idx === -1) {
+              copy.push(raw);
+            } else {
+              copy.splice(idx, 1);
+            }
+
+            return copy;
+          },
+        })
+      );
+
+      // It could happen that the `activeOptionIndex` stored in state is actually null,
+      // but we are getting the fallback active option back instead.
+      $api.goToOption(Focus.Specific, id);
+    },
+    registerOption(id: string, dataRef: ComboboxOptionData) {
+      let option = { id, dataRef };
+      let adjustedState = adjustOrderedState((options) => [...options, option]);
+      
+      // Check if we have a selected value that we can make active.
+      if (activeOptionIndex === null) {
+        let optionValue = (dataRef as any).value;        
+
+        let selected = match(mode, {
+          [ValueMode.Single]: () => $api.compare($api.value, optionValue),
+          [ValueMode.Multi]: () =>
+            ($api.value as unknown[]).some((value) =>
+              $api.compare(value, optionValue)
+            ),
+        });
+
+        if (selected) {
+          adjustedState.activeOptionIndex =
+            adjustedState.options.indexOf(option);
+        }
+      }
+
+      options = adjustedState.options;
+      activeOptionIndex = adjustedState.activeOptionIndex;
+      activationTrigger = ActivationTrigger.Other;
+    },
+    unregisterOption(id: string) {
+      let adjustedState = adjustOrderedState((options) => {
+        let idx = options.findIndex((a) => a.id === id);
+        if (idx !== -1) options.splice(idx, 1);
+        return options;
+      });
+
+      options = adjustedState.options;
+      activeOptionIndex = adjustedState.activeOptionIndex;
+      activationTrigger = ActivationTrigger.Other;
+    },
+  });
+  setContext(COMBOBOX_CONTEXT_NAME, api);
+
+  // Handle outside click
+  // useOutsideClick(
+  //     [inputRef, buttonRef, optionsRef],
+  //     () => api.closeCombobox(),
+  //     computed(() => comboboxState.value === ComboboxStates.Open)
+  //   )
+
+  function handleMousedown(event: MouseEvent) {
+    let target = event.target as HTMLElement;
+    let active = document.activeElement;
+
+    if (comboboxState !== ComboboxStates.Open) return;
+    if ($buttonRef?.contains(target)) return;
+
+    if (!$optionsRef?.contains(target)) $api.closeCombobox();
+    if (active !== document.body && active?.contains(target)) return; // Keep focus on newly clicked/focused element
+    if (!event.defaultPrevented) {
+      $buttonRef?.focus({ preventScroll: true });
+    }
+  }
+
+  function computeOpenClosedState(comboboxState: ComboboxStates) {
+    return match(comboboxState, {
+      [ComboboxStates.Open]: State.Open,
+      [ComboboxStates.Closed]: State.Closed,
+    });
+  }
+
+  let openClosedState = writable<State>(
+    computeOpenClosedState(comboboxState)
+  );
+
+  useOpenClosedProvider(openClosedState);
+  $: $openClosedState = computeOpenClosedState(comboboxState);
+
+  $: activeOption =
+    $api.activeOptionIndex === null
+      ? null
+      : (options[$api.activeOptionIndex]?.dataRef as any);  
+
+  $: api.update((obj) => {
+    return {
+      ...obj,
+      comboboxState,
+      value,
+      options,
+      activeOptionIndex,
+      disabled,
+    };
+  });
+  
+  $: slotProps = {
+    open: comboboxState === ComboboxStates.Open,
+    disabled,
+    activeIndex: $api.activeOptionIndex,
+    activeOption: activeOption,
+    value,
+  };
+</script>
+
+<svelte:window on:mousedown={handleMousedown} />
+
+{$api.activeOptionIndex} | {activeOptionIndex}
+
+{#if name != null && value != null}
+  {@const options = objectToFormEntries({ [name]: value })}
+  {#each options as [optionName, optionValue], index (index)}        
+    <Hidden
+      features={HiddenFeatures.Hidden}
+      as="input"
+      type="hidden"
+      hidden
+      readonly
+      name={optionName}
+      value={optionValue}
+    />
+  {/each}
+{/if}  
+<Render
+  {...$$restProps}
+  {as}
+  {slotProps}
+  use={[...use, forwardEvents]}
+  name={"Combobox"}
+>
+  <slot {...slotProps} />
+</Render>

--- a/src/lib/components/combobox/ComboboxButton.svelte
+++ b/src/lib/components/combobox/ComboboxButton.svelte
@@ -1,0 +1,134 @@
+<script lang="ts" context="module">
+  type TComboboxButtonProps<
+    TSlotProps extends {},
+    TAsProp extends SupportedAs
+  > = TPassThroughProps<TSlotProps, TAsProp, "button"> & {};
+</script>
+
+<script lang="ts">
+  import type { HTMLActionArray } from "$lib/hooks/use-actions";
+  import { useId } from "$lib/hooks/use-id";
+  import type { SupportedAs } from "$lib/internal/elements";
+  import { forwardEventsBuilder } from "$lib/internal/forwardEventsBuilder";
+  import type { TPassThroughProps } from "$lib/types";
+  import { Focus } from "$lib/utils/calculate-active-index";
+  import { Keys } from "$lib/utils/keyboard";
+  import Render from "$lib/utils/Render.svelte";
+  import { resolveButtonType } from "$lib/utils/resolve-button-type";
+  import { tick } from "svelte";
+  import { get_current_component } from "svelte/internal";
+  import { ComboboxStates, useComboboxContext } from "./Combobox.svelte";
+
+  /***** Props *****/
+  type TAsProp = $$Generic<SupportedAs>;
+  type $$Props = TComboboxButtonProps<typeof slotProps, TAsProp>;
+
+  export let as: SupportedAs = "button";
+  export let use: HTMLActionArray = [];
+
+  /***** Events *****/
+  const forwardEvents = forwardEventsBuilder(get_current_component());
+
+  /***** Component *****/
+  let api = useComboboxContext("ComboboxButton");
+  let id = `headlessui-combobox-button-${useId()}`;
+
+  let buttonRef = $api.buttonRef;
+  let optionsRef = $api.optionsRef;
+  let labelRef = $api.labelRef;
+  let inputRef = $api.inputRef;
+  let optionsPropsRef = $api.optionsPropsRef;
+
+  async function handleClick(e: CustomEvent) {
+    let event = e as any as MouseEvent;
+
+    if ($api.disabled) return;
+    if ($api.comboboxState === ComboboxStates.Open) {
+      $api.closeCombobox();
+    } else {
+      event.preventDefault();
+      $api.openCombobox();
+    }
+
+    await tick();
+    $inputRef?.focus({ preventScroll: true });
+  }
+
+  async function handleKeyDown(e: CustomEvent) {
+    let event = e as any as KeyboardEvent;
+
+    switch (event.key) {
+      // Ref: https://www.w3.org/TR/wai-aria-practices-1.2/#keyboard-interaction-12
+
+      case Keys.ArrowDown:
+        event.preventDefault();
+        event.stopPropagation();
+        if ($api.comboboxState === ComboboxStates.Closed) {
+          $api.openCombobox();
+        }
+
+        await tick();
+        $inputRef?.focus({ preventScroll: true });
+        return;
+
+      case Keys.ArrowUp:
+        event.preventDefault();
+        event.stopPropagation();
+        if ($api.comboboxState === ComboboxStates.Closed) {
+          $api.openCombobox();
+          await tick();
+          if (!$api.value) {
+            $api.goToOption(Focus.Last);
+          }
+        }
+
+        await tick();
+        $inputRef?.focus({ preventScroll: true });
+        return;
+
+      case Keys.Escape:
+        if ($api.comboboxState !== ComboboxStates.Open) return;
+        event.preventDefault();
+        if ($optionsRef && !$optionsPropsRef.static) {
+          event.stopPropagation();
+        }
+        $api.closeCombobox();
+        await tick();
+        $inputRef?.focus({ preventScroll: true });
+        return;
+    }
+  }
+
+  $: propsWeControl = {
+    id,
+    type: resolveButtonType({ type: $$props.type, as }, $buttonRef),
+    tabindex: "-1",
+    "aria-haspopup": true,
+    "aria-controls": $optionsRef?.id,
+    "aria-expanded": $api.disabled
+      ? undefined
+      : $api.comboboxState === ComboboxStates.Open,
+    "aria-labelledby": $labelRef ? [$labelRef?.id, id].join(" ") : undefined,
+    disabled: $api.disabled === true ? true : undefined,
+  };
+
+  $: slotProps = {
+    open: $api.comboboxState === ComboboxStates.Open,
+    disabled: $api.disabled,
+    value: $api.value,
+  };
+</script>
+
+<Render
+  {...$$restProps}
+  {...propsWeControl}
+  {as}
+  {slotProps}
+  use={[...use, forwardEvents]}
+  name={"ComboboxButton"}
+  bind:el={$buttonRef}
+  on:click={handleClick}
+  on:keydown={handleKeyDown}
+>
+  <slot {...slotProps} />
+</Render>

--- a/src/lib/components/combobox/ComboboxInput.svelte
+++ b/src/lib/components/combobox/ComboboxInput.svelte
@@ -1,0 +1,233 @@
+<script lang="ts" context="module">
+  type TComboboxInputProps<
+    TSlotProps extends {},
+    TAsProp extends SupportedAs
+  > = TPassThroughProps<TSlotProps, TAsProp, "input"> & {
+    /** Whether the element should ignore the internally managed open/closed state */
+    static?: boolean;
+    /** Whether the element should be unmounted, instead of just hidden, based on the open/closed state	*/
+    unmount?: boolean;
+    /** Pass a function to return the string representation of your value. */
+    displayValue?: (item: any | unknown) => string;
+  };
+</script>
+
+<script lang="ts">
+  import type { HTMLActionArray } from "$lib/hooks/use-actions";
+  import { useId } from "$lib/hooks/use-id";
+  import type { SupportedAs } from "$lib/internal/elements";
+  import { forwardEventsBuilder } from "$lib/internal/forwardEventsBuilder";
+  import { Features, type TPassThroughProps } from "$lib/types";
+  import { Focus } from "$lib/utils/calculate-active-index";
+  import { Keys } from "$lib/utils/keyboard";
+  import { match } from "$lib/utils/match";
+  import Render from "$lib/utils/Render.svelte";
+  import {
+    createEventDispatcher,
+    get_current_component,
+    onMount,
+    tick
+  } from "svelte/internal";
+  import {
+    ComboboxStates,
+    useComboboxContext,
+    ValueMode
+  } from "./Combobox.svelte";
+
+  /***** Props *****/
+  type TAsProp = $$Generic<SupportedAs>;
+  type $$Props = TComboboxInputProps<typeof slotProps, TAsProp>;
+
+  export let as: SupportedAs = "input";
+  export let displayValue: ((item: unknown) => string) | undefined = undefined;
+  export let use: HTMLActionArray = [];
+
+  /***** Events *****/
+  const forwardEvents = forwardEventsBuilder(get_current_component(), [
+    "change",
+  ]);
+
+  const dispatch = createEventDispatcher<{
+    change: any;
+  }>();
+
+  /***** Component *****/
+  let id = `headlessui-combobox-input-${useId()}`;
+  let api = useComboboxContext("ComboboxInput");
+
+  let labelRef = $api.labelRef;
+  let buttonRef = $api.buttonRef;
+  let inputRef = $api.inputRef;
+  let optionsRef = $api.optionsRef;
+  let optionsPropsRef = $api.optionsPropsRef;
+
+  let currentValue = $api.value as unknown as string;
+
+  let getCurrentValue = () => {
+    let value = $api.value;
+    if (!$inputRef) return "";
+
+    if (typeof displayValue !== "undefined") {
+      return displayValue(value as unknown) ?? "";
+    } else if (typeof value === "string") {
+      return value;
+    } else {
+      return "";
+    }
+  };
+
+  function handleStateChange(state: ComboboxStates) {
+    let input = $inputRef;
+    if (!input) return;
+
+    const newValue = getCurrentValue();
+
+    if (state === ComboboxStates.Closed && input.value != newValue)
+      input.value = newValue;
+  }
+  $: handleStateChange($api.comboboxState);
+
+  onMount(() => {
+    $inputRef!.value = getCurrentValue();
+  });
+
+  async function handleKeyDown(e: CustomEvent) {
+    let event = e as any as KeyboardEvent;
+    switch (event.key) {
+      // Ref: https://www.w3.org/TR/wai-aria-practices-1.2/#keyboard-interaction-12
+
+      case Keys.Backspace:
+      case Keys.Delete:
+        if ($api.mode !== ValueMode.Single) return;
+        if (!$api.nullable) return;
+
+        let input = event.currentTarget as HTMLInputElement;
+        requestAnimationFrame(() => {
+          if (input.value === "") {
+            $api.change(null);
+            let options = $optionsRef;
+            if (options) {
+              options.scrollTop = 0;
+            }
+            $api.goToOption(Focus.Nothing);
+          }
+        });
+        break;
+
+      case Keys.Enter:
+        if ($api.comboboxState !== ComboboxStates.Open) return;
+        if (event.isComposing) return;
+
+        event.preventDefault();
+        event.stopPropagation();
+
+        if ($api.activeOptionIndex === null) {
+          $api.closeCombobox();
+          return;
+        }
+
+        $api.selectActiveOption();
+        if ($api.mode === ValueMode.Single) {
+          $api.closeCombobox();
+        }
+        break;
+
+      case Keys.ArrowDown:
+        event.preventDefault();
+        event.stopPropagation();
+        return match($api.comboboxState, {
+          [ComboboxStates.Open]: () => $api.goToOption(Focus.Next),
+          [ComboboxStates.Closed]: () => $api.openCombobox(),
+        });
+
+      case Keys.ArrowUp:
+        event.preventDefault();
+        event.stopPropagation();
+        return match($api.comboboxState, {
+          [ComboboxStates.Open]: () => $api.goToOption(Focus.Previous),
+          [ComboboxStates.Closed]: async () => {
+            $api.openCombobox();
+            await tick();
+            if (!$api.value) {
+              $api.goToOption(Focus.Last);
+            }
+          },
+        });
+
+      case Keys.Home:
+      case Keys.PageUp:
+        event.preventDefault();
+        event.stopPropagation();
+        return $api.goToOption(Focus.First);
+
+      case Keys.End:
+      case Keys.PageDown:
+        event.preventDefault();
+        event.stopPropagation();
+        return $api.goToOption(Focus.Last);
+
+      case Keys.Escape:
+        if ($api.comboboxState !== ComboboxStates.Open) return;
+        event.preventDefault();
+        if ($optionsRef && !$optionsPropsRef.static) {
+          event.stopPropagation();
+        }
+        $api.closeCombobox();
+        break;
+
+      case Keys.Tab:
+        if ($api.comboboxState !== ComboboxStates.Open) return;
+        if ($api.mode === ValueMode.Single) $api.selectActiveOption();
+        $api.closeCombobox();
+        break;
+    }
+  }
+
+  function handleChange(e: Event) {
+    const target = <HTMLInputElement>e.target;
+    dispatch("change", target.value);
+  }
+
+  function handleInput(e: Event) {
+    const target = <HTMLInputElement>e.target;
+    $api.openCombobox();
+    dispatch("change", target.value);
+  }
+
+  $: propsWeControl = {
+    "aria-controls": $optionsRef?.id,
+    "aria-expanded": $api.disabled
+      ? undefined
+      : $api.comboboxState === ComboboxStates.Open,
+    "aria-activedescendant":
+      $api.activeOptionIndex === null
+        ? undefined
+        : $api.options[$api.activeOptionIndex]?.id,
+    "aria-multiselectable": $api.mode === ValueMode.Multi ? true : undefined,
+    "aria-labelledby": $labelRef?.id ?? $buttonRef?.id,
+    id,
+    role: "combobox",
+    type: $$restProps.type ?? "text",
+    tabIndex: 0,
+  };
+
+  $: slotProps = {
+    open: $api.comboboxState === ComboboxStates.Open,
+  };
+</script>
+
+<Render
+  {...$$restProps}
+  {...propsWeControl}
+  {as}
+  {slotProps}
+  use={[...use, forwardEvents]}
+  name={"ComboboxInput"}
+  bind:el={$inputRef}
+  on:input={handleInput}
+  on:keydown={handleKeyDown}
+  on:change={handleChange}
+  features={Features.RenderStrategy | Features.Static}
+>
+  <slot {...slotProps} />
+</Render>

--- a/src/lib/components/combobox/ComboboxLabel.svelte
+++ b/src/lib/components/combobox/ComboboxLabel.svelte
@@ -1,0 +1,57 @@
+<script lang="ts" context="module">
+    type TComboboxLabelProps<
+      TSlotProps extends {},
+      TAsProp extends SupportedAs
+    > = TPassThroughProps<TSlotProps, TAsProp, "label"> & {};
+  </script>
+  
+  <script lang="ts">
+    import { ComboboxStates, useComboboxContext } from "./Combobox.svelte";
+    import { useId } from "$lib/hooks/use-id";
+    import Render from "$lib/utils/Render.svelte";
+    import { forwardEventsBuilder } from "$lib/internal/forwardEventsBuilder";
+    import type { SupportedAs } from "$lib/internal/elements";
+    import type { HTMLActionArray } from "$lib/hooks/use-actions";
+    import { get_current_component } from "svelte/internal";
+    import type { TPassThroughProps } from "$lib/types";
+  
+    /***** Props *****/
+    type TAsProp = $$Generic<SupportedAs>;
+    type $$Props = TComboboxLabelProps<typeof slotProps, TAsProp>;
+  
+    export let as: SupportedAs = "label";
+    export let use: HTMLActionArray = [];
+  
+    /***** Events *****/
+    const forwardEvents = forwardEventsBuilder(get_current_component());
+  
+    /***** Component *****/
+    let id = `headlessui-combobox-label-${useId()}`;
+    let api = useComboboxContext("ComboboxLabel");
+  
+    let labelRef = $api.labelRef;
+    let inputRef = $api.inputRef;
+  
+    function handleClick(): void {
+      $inputRef?.focus({ preventScroll: true });
+    }
+  
+    $: slotProps = {
+      open: $api.comboboxState === ComboboxStates.Open,
+      disabled: $api.disabled,
+    };
+  </script>
+  
+  <Render
+    {...$$restProps}
+    {id}
+    {as}
+    {slotProps}
+    use={[...use, forwardEvents]}
+    name={"ComboboxLabel"}
+    bind:el={$labelRef}
+    on:click={handleClick}
+  >
+    <slot {...slotProps} />
+  </Render>
+  

--- a/src/lib/components/combobox/ComboboxOption.svelte
+++ b/src/lib/components/combobox/ComboboxOption.svelte
@@ -1,0 +1,154 @@
+<script lang="ts" context="module">
+  type TComboboxOptionProps<
+    TSlotProps extends {},
+    TAsProp extends SupportedAs
+  > = TPassThroughProps<TSlotProps, TAsProp, "li"> & {
+    /** The option value */
+    value: unknown;
+    /** Whether the option should be disabled for keyboard navigation and ARIA purposes */
+    disabled?: boolean;
+  };
+</script>
+
+<script lang="ts">
+  import {
+    ActivationTrigger,
+    ComboboxStates,
+    useComboboxContext,
+    ValueMode,
+    type ComboboxOptionData,
+  } from "./Combobox.svelte";
+  import { useId } from "$lib/hooks/use-id";
+  import Render from "$lib/utils/Render.svelte";
+  import { forwardEventsBuilder } from "$lib/internal/forwardEventsBuilder";
+  import type { SupportedAs } from "$lib/internal/elements";
+  import type { HTMLActionArray } from "$lib/hooks/use-actions";
+  import { get_current_component, onMount, tick } from "svelte/internal";
+  import type { TPassThroughProps } from "$lib/types";
+  import { writable, type Writable } from "svelte/store";
+  import { match } from "$lib/utils/match";
+  import { Focus } from "$lib/utils/calculate-active-index";
+
+  /***** Props *****/
+  type TAsProp = $$Generic<SupportedAs>;
+  type $$Props = TComboboxOptionProps<typeof slotProps, TAsProp>;
+
+  export let as: SupportedAs = "li";
+  export let value: Object | string | number | boolean;
+  export let disabled: boolean = false;
+  export let use: HTMLActionArray = [];
+
+  /***** Events *****/
+  const forwardEvents = forwardEventsBuilder(get_current_component());
+
+  /***** Component *****/
+  let id = `headlessui-combobox-option-${useId()}`;
+  let api = useComboboxContext("ComboboxOption");
+
+  let internalOptionRef: Writable<HTMLElement | null> = writable(null);
+  let optionsPropsRef = $api.optionsPropsRef;
+
+  $: active =
+    $api.activeOptionIndex !== null
+      ? $api.options[$api.activeOptionIndex].id === id
+      : false;
+
+  $: selected = match($api.mode, {
+    [ValueMode.Single]: () => $api.compare($api.value, value),
+    [ValueMode.Multi]: () =>
+      ($api.value as unknown[]).some((v) => $api.compare(v, value)),
+  });
+
+  $: dataRef = {
+    disabled: disabled,
+    value: value,
+    domRef: internalOptionRef,
+  } as ComboboxOptionData;
+
+  onMount(() => {
+    $api.registerOption(id, dataRef);
+    return () => {
+      $api.unregisterOption(id);
+    };
+  });
+
+  async function scrollIntoViewIfActive(
+    newState: ComboboxStates,
+    newActive: boolean,
+    newActivationTrigger: ActivationTrigger
+  ) {
+    if (newState !== ComboboxStates.Open) return;
+    if (!newActive) return;
+    if (newActivationTrigger === ActivationTrigger.Pointer) return;
+
+    await tick();
+
+    $internalOptionRef?.scrollIntoView?.({ block: "nearest" });
+  }
+
+  $: scrollIntoViewIfActive($api.comboboxState, active, $api.activationTrigger);
+
+  function handleClick(e: CustomEvent) {
+    let event = e as any as KeyboardEvent;
+    if (disabled) return event.preventDefault();
+    $api.selectOption(id);
+    if ($api.mode === ValueMode.Single) {
+      $api.closeCombobox();
+    }
+  }
+
+  function handleFocus() {
+    if (disabled) return $api.goToOption(Focus.Nothing);
+    $api.goToOption(Focus.Specific, id);
+  }
+
+  function handleMove() {
+    if (disabled) return;
+    if (active) return;
+    $api.goToOption(Focus.Specific, id, ActivationTrigger.Pointer);
+  }
+
+  function handleLeave() {
+    if (disabled) return;
+    if (!active) return;
+    if ($optionsPropsRef.hold) return;
+    $api.goToOption(Focus.Nothing);
+  }
+
+  $: propsWeControl = {
+    id,
+    ref: internalOptionRef,
+    role: "option",
+    tabIndex: disabled === true ? undefined : -1,
+    "aria-disabled": disabled === true ? true : undefined,
+    // According to the WAI-ARIA best practices, we should use aria-checked for
+    // multi-select,but Voice-Over disagrees. So we use aria-checked instead for
+    // both single and multi-select.
+    "aria-selected": selected,
+    disabled: undefined, // Never forward the `disabled` prop
+  };
+
+  $: slotProps = {
+    active,
+    selected,
+    disabled,
+  };
+</script>
+
+<Render
+  {...$$restProps}
+  {...propsWeControl}
+  {as}
+  {slotProps}
+  use={[...use, forwardEvents]}
+  name={"ComboboxOption"}
+  bind:el={$internalOptionRef}
+  on:click={handleClick}
+  on:focus={handleFocus}
+  on:pointermove={handleMove}
+  on:mousemove={handleMove}
+  on:pointerleave={handleLeave}
+  on:mouseleave={handleLeave}
+>
+  <slot {...slotProps} />
+</Render>

--- a/src/lib/components/combobox/ComboboxOptions.svelte
+++ b/src/lib/components/combobox/ComboboxOptions.svelte
@@ -1,0 +1,99 @@
+<script lang="ts" context="module">
+  type TComboboxOptionsProps<
+    TSlotProps extends {},
+    TAsProp extends SupportedAs
+  > = TPassThroughProps<TSlotProps, TAsProp, "ul"> & {
+    /** Whether the element should ignore the internally managed open/closed state */
+    static?: boolean;
+    /** Whether the element should be unmounted, instead of just hidden, based on the open/closed state	*/
+    unmount?: boolean;
+    /** */
+    hold?: boolean;
+  };
+</script>
+
+<script lang="ts">
+  import { ComboboxStates, useComboboxContext } from "./Combobox.svelte";
+  import { useId } from "$lib/hooks/use-id";
+  import Render from "$lib/utils/Render.svelte";
+  import { forwardEventsBuilder } from "$lib/internal/forwardEventsBuilder";
+  import type { SupportedAs } from "$lib/internal/elements";
+  import type { HTMLActionArray } from "$lib/hooks/use-actions";
+  import { get_current_component } from "svelte/internal";
+  import { Features, type TPassThroughProps } from "$lib/types";
+  import { State, useOpenClosed } from "$lib/internal/open-closed";
+  import { treeWalker } from "$lib/hooks/use-tree-walker";
+
+  /***** Props *****/
+  type TAsProp = $$Generic<SupportedAs>;
+  type $$Props = TComboboxOptionsProps<typeof slotProps, TAsProp>;
+
+  export let as: SupportedAs = "ul";
+  export let hold: boolean = false;
+  let _static: boolean = false;
+  export { _static as static };
+  export let use: HTMLActionArray = [];
+
+  /***** Events *****/
+  const forwardEvents = forwardEventsBuilder(get_current_component());
+
+  /***** Component *****/
+  let id = `headlessui-combobox-options-${useId()}`;
+  let api = useComboboxContext("ComboboxOptions");
+
+  let labelRef = $api.labelRef;
+  let buttonRef = $api.buttonRef;
+  let optionsRef = $api.optionsRef;
+  let optionsPropsRef = $api.optionsPropsRef;
+
+  $: $optionsPropsRef.static = _static;
+  $: $optionsPropsRef.hold = hold;
+
+  let usesOpenClosedState = useOpenClosed();
+  $: visible =
+    usesOpenClosedState !== undefined
+      ? $usesOpenClosedState === State.Open
+      : $api.comboboxState === ComboboxStates.Open;
+
+  $: treeWalker({
+    container: $optionsRef,
+    enabled: $api.comboboxState === ComboboxStates.Open,
+    accept(node) {
+      if (node.getAttribute("role") === "option")
+        return NodeFilter.FILTER_REJECT;
+      if (node.hasAttribute("role")) return NodeFilter.FILTER_SKIP;
+      return NodeFilter.FILTER_ACCEPT;
+    },
+    walk(node) {
+      node.setAttribute("role", "none");
+    },
+  });
+
+  $: propsWeControl = {
+    "aria-activedescendant":
+      $api.activeOptionIndex === null
+        ? undefined
+        : $api.options[$api.activeOptionIndex]?.id,
+    "aria-labelledby": $labelRef?.id ?? $buttonRef?.id,
+    id,
+    role: "listbox",    
+  };
+
+  $: slotProps = {
+    open: $api.comboboxState === ComboboxStates.Open,
+  };
+</script>
+
+<Render
+  {...$$restProps}
+  {...propsWeControl}
+  {as}
+  {slotProps}
+  use={[...use, forwardEvents]}
+  name={"ComboboxOptions"}
+  bind:el={$optionsRef}
+  {visible}
+  features={Features.RenderStrategy | Features.Static}
+>
+  <slot {...slotProps} />
+</Render>

--- a/src/lib/components/combobox/combobox.test.ts
+++ b/src/lib/components/combobox/combobox.test.ts
@@ -1,0 +1,5756 @@
+import {
+  Combobox,
+  ComboboxInput,
+  ComboboxButton,
+  ComboboxLabel,
+  ComboboxOption,
+  ComboboxOptions,
+} from ".";
+import { suppressConsoleLogs } from "$lib/test-utils/suppress-console-logs";
+import { act, render } from "@testing-library/svelte";
+import {
+  assertActiveElement,
+  assertActiveComboboxOption,
+  assertCombobox,
+  assertComboboxButton,
+  assertComboboxButtonLinkedWithCombobox,
+  assertComboboxButtonLinkedWithComboboxLabel,
+  assertComboboxLabel,
+  assertComboboxLabelLinkedWithCombobox,
+  assertComboboxOption,
+  assertNoActiveComboboxOption,
+  assertNoSelectedComboboxOption,
+  getByText,
+  getCombobox,
+  getComboboxButton,
+  getComboboxButtons,
+  getComboboxes,
+  getComboboxLabel,
+  getComboboxOptions,
+  ComboboxState,
+  assertComboboxList,
+  getComboboxInput,
+  assertComboboxInput,
+  assertNotActiveComboboxOption,
+  getComboboxInputs,
+  ComboboxMode,
+} from "$lib/test-utils/accessibility-assertions";
+import {
+  click,
+  focus,
+  Keys,
+  MouseButton,
+  mouseLeave,
+  mouseMove,
+  press,
+  shift,
+  type,
+  word,
+} from "$lib/test-utils/interactions";
+import { Transition } from "../transitions";
+import TransitionDebug from "$lib/components/disclosure/_TransitionDebug.svelte";
+import svelte from "svelte-inline-compile";
+import { writable } from "svelte/store";
+
+let NOOP = () => {};
+
+let mockId = 0;
+jest.mock("../../hooks/use-id", () => {
+  return {
+    useId: jest.fn(() => ++mockId),
+  };
+});
+
+beforeEach(() => (mockId = 0));
+beforeAll(() => {
+  //jest.spyOn(window, 'requestAnimationFrame').mockImplementation(setImmediate as any)
+  //jest.spyOn(window, 'cancelAnimationFrame').mockImplementation(clearImmediate as any)
+});
+afterAll(() => jest.restoreAllMocks());
+
+function nextFrame() {
+  return new Promise<void>((resolve) => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        resolve();
+      });
+    });
+  });
+}
+
+describe("safeguards", () => {
+  it.each([
+    ["ComboboxButton", ComboboxButton],
+    ["ComboboxLabel", ComboboxLabel],
+    ["ComboboxOptions", ComboboxOptions],
+    ["ComboboxOption", ComboboxOption],
+  ])(
+    "should error when we are using a <%s /> without a parent <Combobox />",
+    suppressConsoleLogs((name, Component) => {
+      expect(() => render(Component)).toThrowError(
+        `<${name} /> is missing a parent <Combobox /> component.`
+      );
+    })
+  );
+
+  it(
+    "should be possible to render a Combobox without crashing",
+    suppressConsoleLogs(async () => {
+      render(svelte`svelte
+          <Combobox value="test" on:change={console.log}>
+            <ComboboxInput on:change={NOOP} />
+            <ComboboxButton>Trigger</ComboboxButton>
+            <ComboboxOptions>
+              <ComboboxOption value="a">Option A</ComboboxOption>
+              <ComboboxOption value="b">Option B</ComboboxOption>
+              <ComboboxOption value="c">Option C</ComboboxOption>
+            </ComboboxOptions>
+          </Combobox>
+        `);
+
+      assertComboboxButton({
+        state: ComboboxState.InvisibleUnmounted,
+        attributes: { id: "headlessui-combobox-button-2" },
+      });
+      assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+    })
+  );
+});
+
+describe("Rendering", () => {
+  describe("Combobox", () => {
+    it(
+      "should be possible to render a Combobox using a slot prop",
+      suppressConsoleLogs(async () => {
+        render(svelte`
+          <Combobox value="test" on:change={console.log} let:open>            
+            <ComboboxInput on:change={NOOP} />
+            <ComboboxButton>Trigger</ComboboxButton>
+                {#if open}
+                    <ComboboxOptions>
+                        <ComboboxOption value="a">Option A</ComboboxOption>
+                        <ComboboxOption value="b">Option B</ComboboxOption>
+                        <ComboboxOption value="c">Option C</ComboboxOption>
+                    </ComboboxOptions>
+                {/if}              
+          </Combobox>
+        `);
+
+        assertComboboxButton({
+          state: ComboboxState.InvisibleUnmounted,
+          attributes: { id: "headlessui-combobox-button-2" },
+        });
+        assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+        await click(getComboboxButton());
+
+        assertComboboxButton({
+          state: ComboboxState.Visible,
+          attributes: { id: "headlessui-combobox-button-2" },
+        });
+        assertComboboxList({ state: ComboboxState.Visible });
+      })
+    );
+
+    it(
+      "should be possible to disable a Combobox",
+      suppressConsoleLogs(async () => {
+        render(svelte`
+          <Combobox value={undefined} on:change={console.log} disabled>
+            <ComboboxInput on:change={NOOP} />
+            <ComboboxButton>Trigger</ComboboxButton>
+            <ComboboxOptions>
+              <ComboboxOption value="a">Option A</ComboboxOption>
+              <ComboboxOption value="b">Option B</ComboboxOption>
+              <ComboboxOption value="c">Option C</ComboboxOption>
+            </ComboboxOptions>
+          </Combobox>
+        `);
+
+        assertComboboxButton({
+          state: ComboboxState.InvisibleUnmounted,
+          attributes: { id: "headlessui-combobox-button-2" },
+        });
+        assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+        await click(getComboboxButton());
+
+        assertComboboxButton({
+          state: ComboboxState.InvisibleUnmounted,
+          attributes: { id: "headlessui-combobox-button-2" },
+        });
+        assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+        await press(Keys.Enter, getComboboxButton());
+
+        assertComboboxButton({
+          state: ComboboxState.InvisibleUnmounted,
+          attributes: { id: "headlessui-combobox-button-2" },
+        });
+        assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+      })
+    );
+
+    describe("Equality", () => {
+      it(
+        "should use object equality by default",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <script>
+            let options = [
+                { id: 1, name: "Alice" },
+                { id: 2, name: "Bob" },
+                { id: 3, name: "Charlie" },
+            ];
+            </script> 
+
+            <Combobox value={options[1]} on:change={console.log}>
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+              {#each options as option}
+                  <ComboboxOption                    
+                    value={option}
+                    class={(info) => JSON.stringify(info)}
+                  >
+                    {option.name}
+                  </ComboboxOption>
+                {/each}
+              </ComboboxOptions>
+            </Combobox>
+          `);
+
+          await click(getComboboxButton());
+
+          let bob = getComboboxOptions()[1];
+          expect(bob).toHaveAttribute(
+            "class",
+            JSON.stringify({ active: true, selected: true, disabled: false })
+          );
+        })
+      );
+
+      it(
+        "should be possible to compare null values by a field",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+          <script>
+            let options = [
+                { id: 1, name: "Alice" },
+                { id: 2, name: "Bob" },
+                { id: 3, name: "Charlie" },
+            ];
+            </script> 
+            <Combobox value={null} on:change={console.log} by="id">
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                {#each options as option}
+                  <ComboboxOption                    
+                    value={option}
+                    class={(info) => JSON.stringify(info)}
+                  >
+                    {option.name}
+                  </ComboboxOption>
+                {/each}
+              </ComboboxOptions>
+            </Combobox>
+          `);
+
+          await click(getComboboxButton());
+
+          let [alice, bob, charlie] = getComboboxOptions();
+          expect(alice).toHaveAttribute(
+            "class",
+            JSON.stringify({ active: true, selected: false, disabled: false })
+          );
+          expect(bob).toHaveAttribute(
+            "class",
+            JSON.stringify({ active: false, selected: false, disabled: false })
+          );
+          expect(charlie).toHaveAttribute(
+            "class",
+            JSON.stringify({ active: false, selected: false, disabled: false })
+          );
+        })
+      );
+
+      it(
+        "should be possible to compare objects by a field",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+          <script>
+            let options = [
+                { id: 1, name: "Alice" },
+                { id: 2, name: "Bob" },
+                { id: 3, name: "Charlie" },
+            ];
+            </script> 
+            <Combobox
+              value={{ id: 2, name: "Bob" }}
+              on:change={console.log}
+              by="id"
+            >
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                {#each options as option}
+                  <ComboboxOption                    
+                    value={option}
+                    class={(info) => JSON.stringify(info)}
+                  >
+                    {option.name}
+                  </ComboboxOption>
+                {/each}
+              </ComboboxOptions>
+            </Combobox>
+          `);
+
+          await click(getComboboxButton());
+
+          let bob = getComboboxOptions()[1];
+          expect(bob).toHaveAttribute(
+            "class",
+            JSON.stringify({ active: true, selected: true, disabled: false })
+          );
+        })
+      );
+
+      it(
+        "should be possible to compare objects by a comparator function",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+          <script>
+            let options = [
+                { id: 1, name: "Alice" },
+                { id: 2, name: "Bob" },
+                { id: 3, name: "Charlie" },
+            ];
+
+            function compareFunc(a, z) {                
+                return a.id === z.id
+            }
+            </script> 
+            <Combobox
+              value={{ id: 2, name: "Bob" }}
+              on:change={console.log}
+              by={compareFunc}
+            >
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+              {#each options as option}
+                  <ComboboxOption                    
+                    value={option}
+                    class={(info) => JSON.stringify(info)}
+                  >
+                    {option.name}
+                  </ComboboxOption>
+                {/each}
+              </ComboboxOptions>
+            </Combobox>
+          `);
+
+          await click(getComboboxButton());
+
+          let bob = getComboboxOptions()[1];
+          expect(bob).toHaveAttribute(
+            "class",
+            JSON.stringify({ active: true, selected: true, disabled: false })
+          );
+        })
+      );
+
+      it(
+        "should be possible to use completely new objects while rendering (single mode)",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <script>
+                let value = { id: 2, name: "Bob" }
+            </script>
+
+          <Combobox
+                value={value}
+                on:change={(e) => (value = e.detail)}
+                by="id"
+              >
+                <ComboboxButton>Trigger</ComboboxButton>
+                <ComboboxOptions>
+                  <ComboboxOption value={{ id: 1, name: "alice" }}>
+                    alice
+                  </ComboboxOption>
+                  <ComboboxOption value={{ id: 2, name: "bob" }}>
+                    bob
+                  </ComboboxOption>
+                  <ComboboxOption value={{ id: 3, name: "charlie" }}>
+                    charlie
+                  </ComboboxOption>
+                </ComboboxOptions>
+              </Combobox>
+          `);
+
+          await click(getComboboxButton());
+          let [alice, bob, charlie] = getComboboxOptions();
+          expect(alice).toHaveAttribute("aria-selected", "false");
+          expect(bob).toHaveAttribute("aria-selected", "true");
+          expect(charlie).toHaveAttribute("aria-selected", "false");
+
+          await click(getComboboxOptions()[2]);
+          await click(getComboboxButton());
+          [alice, bob, charlie] = getComboboxOptions();
+          expect(alice).toHaveAttribute("aria-selected", "false");
+          expect(bob).toHaveAttribute("aria-selected", "false");
+          expect(charlie).toHaveAttribute("aria-selected", "true");
+
+          await click(getComboboxOptions()[1]);
+          await click(getComboboxButton());
+          [alice, bob, charlie] = getComboboxOptions();
+          expect(alice).toHaveAttribute("aria-selected", "false");
+          expect(bob).toHaveAttribute("aria-selected", "true");
+          expect(charlie).toHaveAttribute("aria-selected", "false");
+        })
+      );
+
+      it(
+        "should be possible to use completely new objects while rendering (multiple mode)",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+          <script>
+            let value = [{ id: 2, name: "bob" }]
+            </script>
+          <Combobox
+                value={value}
+                on:change={(e) => (value = e.detail)}
+                by="id"
+                multiple={true}
+              >
+                <ComboboxButton>Trigger</ComboboxButton>
+                <ComboboxOptions>
+                  <ComboboxOption value={{ id: 1, name: "alice" }}>
+                    alice
+                  </ComboboxOption>
+                  <ComboboxOption value={{ id: 2, name: "bob" }}>
+                    bob
+                  </ComboboxOption>
+                  <ComboboxOption value={{ id: 3, name: "charlie" }}>
+                    charlie
+                  </ComboboxOption>
+                </ComboboxOptions>
+              </Combobox>
+          `);
+
+          await click(getComboboxButton());
+
+          await click(getComboboxOptions()[2]);
+          let [alice, bob, charlie] = getComboboxOptions();
+          expect(alice).toHaveAttribute("aria-selected", "false");
+          expect(bob).toHaveAttribute("aria-selected", "true");
+          expect(charlie).toHaveAttribute("aria-selected", "true");
+
+          await click(getComboboxOptions()[2]);
+          [alice, bob, charlie] = getComboboxOptions();
+          expect(alice).toHaveAttribute("aria-selected", "false");
+          expect(bob).toHaveAttribute("aria-selected", "true");
+          expect(charlie).toHaveAttribute("aria-selected", "false");
+        })
+      );
+    });
+  });
+});
+
+describe("ComboboxInput", () => {
+  it(
+    "selecting an option puts the value into ComboboxInput when displayValue is not provided",
+    suppressConsoleLogs(async () => {
+      render(svelte`
+        <script>
+            let value = undefined
+        </script>
+
+        <Combobox value={value} on:change={(e) => (value = e.detail)}>
+          <ComboboxInput on:change={NOOP} />
+          <ComboboxButton>Trigger</ComboboxButton>
+          <ComboboxOptions>
+            <ComboboxOption value="a">Option A</ComboboxOption>
+            <ComboboxOption value="b">Option B</ComboboxOption>
+            <ComboboxOption value="c">Option C</ComboboxOption>
+          </ComboboxOptions>
+        </Combobox>
+        `);
+
+      assertComboboxInput({ state: ComboboxState.InvisibleUnmounted });
+
+      await click(getComboboxButton());
+
+      assertComboboxInput({ state: ComboboxState.Visible });
+      assertComboboxList({ state: ComboboxState.Visible });
+
+      await click(getComboboxOptions()[1]);
+
+      expect(getComboboxInput()).toHaveValue("b");
+    })
+  );
+
+  it(
+    "selecting an option puts the display value into ComboboxInput when displayValue is provided",
+    suppressConsoleLogs(async () => {
+      render(svelte`
+        <script>
+            let value = undefined
+        </script>
+
+        <Combobox value={value} on:change={(e) => (value = e.detail)}>
+          <ComboboxInput
+            on:change={NOOP}
+            displayValue={(str) => str?.toUpperCase() ?? ""}
+          />
+          <ComboboxButton>Trigger</ComboboxButton>
+          <ComboboxOptions>
+            <ComboboxOption value="a">Option A</ComboboxOption>
+            <ComboboxOption value="b">Option B</ComboboxOption>
+            <ComboboxOption value="c">Option C</ComboboxOption>
+          </ComboboxOptions>
+        </Combobox>
+        `);
+
+      await click(getComboboxButton());
+
+      assertComboboxList({ state: ComboboxState.Visible });
+
+      await click(getComboboxOptions()[1]);
+
+      expect(getComboboxInput()).toHaveValue("B");
+    })
+  );
+
+  it(
+    "selecting an option puts the display value into ComboboxInput when displayValue is provided (when value is undefined)",
+    suppressConsoleLogs(async () => {
+      render(svelte`
+      <script>
+        let value = undefined
+      </script>
+
+      <Combobox value={value} on:change={(e) => (value = e.detail)}>
+        <ComboboxInput
+          on:change={NOOP}
+          displayValue={(str) => str?.toUpperCase() ?? ""}
+        />
+        <ComboboxButton>Trigger</ComboboxButton>
+        <ComboboxOptions>
+          <ComboboxOption value="a">Option A</ComboboxOption>
+          <ComboboxOption value="b">Option B</ComboboxOption>
+          <ComboboxOption value="c">Option C</ComboboxOption>
+        </ComboboxOptions>
+      </Combobox>
+      `);
+
+      // Focus the input
+      await focus(getComboboxInput());
+
+      // Type in it
+      await type(word("A"), getComboboxInput());
+
+      // Stop typing (and clear the input)
+      await press(Keys.Escape, getComboboxInput());
+
+      // Focus the body (so the input loses focus)
+      await focus(document.body);
+
+      expect(getComboboxInput()).toHaveValue("");
+    })
+  );
+
+  it(
+    "conditionally rendering the input should allow changing the display value",
+    suppressConsoleLogs(async () => {
+      render(svelte`
+      <script>
+        let value = null
+        let suffix = false
+
+        function displayFunc(str) {
+          return (str?.toUpperCase() ?? "") + " " + (suffix ? "with suffix" : "no suffix")         
+        }
+      </script>
+
+        <Combobox value={value} on:change={(e) => (value = e.detail)} nullable>
+          <ComboboxInput
+            on:change={NOOP}
+            displayValue={displayFunc}
+          />
+          <ComboboxButton>Trigger</ComboboxButton>
+          <ComboboxOptions>
+            <ComboboxOption value="a">Option A</ComboboxOption>
+            <ComboboxOption value="b">Option B</ComboboxOption>
+            <ComboboxOption value="c">Option C</ComboboxOption>
+          </ComboboxOptions>
+          <button on:click={() => suffix = !suffix}>
+            Toggle suffix
+          </button>
+      </Combobox>
+      `);
+
+      expect(getComboboxInput()).toHaveValue(" no suffix");
+
+      await click(getComboboxButton());
+
+      expect(getComboboxInput()).toHaveValue(" no suffix");
+
+      await click(getComboboxOptions()[1]);
+
+      expect(getComboboxInput()).toHaveValue("B no suffix");
+
+      await click(getByText("Toggle suffix"));
+
+      expect(getComboboxInput()).toHaveValue("B no suffix"); // No re-sync yet
+
+      await click(getComboboxButton());
+
+      expect(getComboboxInput()).toHaveValue("B no suffix"); // No re-sync yet
+
+      await click(getComboboxOptions()[0]);
+
+      expect(getComboboxInput()).toHaveValue("A with suffix");
+    })
+  );
+
+  it(
+    "should be possible to override the `type` on the input",
+    suppressConsoleLogs(async () => {
+      render(svelte`
+      <script>
+        let value = undefined        
+      </script>
+      <Combobox value={value} on:change={(e) => (value = e.detail)}>
+            <ComboboxInput type="search" on:change={NOOP} />
+            <ComboboxButton>Trigger</ComboboxButton>
+            <ComboboxOptions>
+              <ComboboxOption value="a">Option A</ComboboxOption>
+              <ComboboxOption value="b">Option B</ComboboxOption>
+              <ComboboxOption value="c">Option C</ComboboxOption>
+            </ComboboxOptions>
+          </Combobox>
+      `);
+
+      expect(getComboboxInput()).toHaveAttribute("type", "search");
+    })
+  );
+
+  xit(
+    "should reflect the value in the input when the value changes and when you are typing",
+    suppressConsoleLogs(async () => {
+      render(svelte`
+      <script>
+        let value = "bob"
+        let _query = ""
+      </script>
+      
+      <Combobox value={value} on:change={(e) => (value = e.detail)} let:open>
+      {#if open}
+          <ComboboxInput
+            on:change={(e) => (_query = e.detail)}
+            displayValue={(person) => (person ?? "") + " - " + (open ? "open" : "closed")}
+          />
+
+            <ComboboxButton />
+
+            <ComboboxOptions>
+              <ComboboxOption value="alice">alice</ComboboxOption>
+              <ComboboxOption value="bob">bob</ComboboxOption>
+              <ComboboxOption value="charlie">charlie</ComboboxOption>
+            </ComboboxOptions>
+        {/if}
+      </Combobox>
+      `);
+
+      // Check for proper state sync
+      expect(getComboboxInput()).toHaveValue("bob - closed");
+      await click(getComboboxButton());
+      expect(getComboboxInput()).toHaveValue("bob - open");
+      await click(getComboboxButton());
+      expect(getComboboxInput()).toHaveValue("bob - closed");
+
+      // Check if we can still edit the input
+      for (let _ of Array(" - closed".length)) {
+        await press(Keys.Backspace, getComboboxInput());
+      }
+      getComboboxInput()?.select();
+      await type(word("alice"), getComboboxInput());
+      expect(getComboboxInput()).toHaveValue("alice");
+
+      // Open the combobox and choose an option
+      await click(getComboboxOptions()[2]);
+      expect(getComboboxInput()).toHaveValue("charlie - closed");
+    })
+  );
+});
+
+describe("ComboboxLabel", () => {
+  it(
+    "should be possible to render a ComboboxLabel using a slot prop",
+    suppressConsoleLogs(async () => {
+      render(svelte`
+          <Combobox value="test" on:change={console.log}>
+            <ComboboxLabel let:open let:disabled>{JSON.stringify({ open, disabled })}</ComboboxLabel>
+            <ComboboxInput on:change={NOOP} />
+            <ComboboxButton>Trigger</ComboboxButton>
+            <ComboboxOptions>
+              <ComboboxOption value="a">Option A</ComboboxOption>
+              <ComboboxOption value="b">Option B</ComboboxOption>
+              <ComboboxOption value="c">Option C</ComboboxOption>
+            </ComboboxOptions>
+          </Combobox>
+        `);
+
+      assertComboboxButton({
+        state: ComboboxState.InvisibleUnmounted,
+        attributes: { id: "headlessui-combobox-button-3" },
+      });
+      assertComboboxLabel({
+        attributes: { id: "headlessui-combobox-label-1" },
+        textContent: JSON.stringify({ open: false, disabled: false }),
+      });
+      assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+      await click(getComboboxButton());
+
+      assertComboboxLabel({
+        attributes: { id: "headlessui-combobox-label-1" },
+        textContent: JSON.stringify({ open: true, disabled: false }),
+      });
+      assertComboboxList({ state: ComboboxState.Visible });
+      assertComboboxLabelLinkedWithCombobox();
+      assertComboboxButtonLinkedWithComboboxLabel();
+    })
+  );
+
+  it(
+    "should be possible to link Input/Button and Label if Label is rendered last",
+    suppressConsoleLogs(async () => {
+      render(svelte`
+          <Combobox value="Test" on:change={console.log}>
+            <ComboboxInput on:change={NOOP} />
+            <ComboboxButton />
+            <ComboboxLabel>Label</ComboboxLabel>
+          </Combobox>
+        `);
+
+      assertComboboxLabelLinkedWithCombobox();
+      assertComboboxButtonLinkedWithComboboxLabel();
+    })
+  );
+
+  it(
+    "should be possible to render a ComboboxLabel using a slot prop and an `as` prop",
+    suppressConsoleLogs(async () => {
+      render(svelte`
+          <Combobox value="test" on:change={console.log}>
+            <ComboboxLabel as="p" let:open let:disabled>{JSON.stringify({ open, disabled })}</ComboboxLabel>
+            <ComboboxInput on:change={NOOP} />
+            <ComboboxButton>Trigger</ComboboxButton>
+            <ComboboxOptions>
+              <ComboboxOption value="a">Option A</ComboboxOption>
+              <ComboboxOption value="b">Option B</ComboboxOption>
+              <ComboboxOption value="c">Option C</ComboboxOption>
+            </ComboboxOptions>
+          </Combobox>
+        `);
+
+      assertComboboxLabel({
+        attributes: { id: "headlessui-combobox-label-1" },
+        textContent: JSON.stringify({ open: false, disabled: false }),
+        tag: "p",
+      });
+      assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+      await click(getComboboxButton());
+      assertComboboxLabel({
+        attributes: { id: "headlessui-combobox-label-1" },
+        textContent: JSON.stringify({ open: true, disabled: false }),
+        tag: "p",
+      });
+      assertComboboxList({ state: ComboboxState.Visible });
+    })
+  );
+});
+
+describe("ComboboxButton", () => {
+  it(
+    "should be possible to render a ComboboxButton using a slot prop",
+    suppressConsoleLogs(async () => {
+      render(svelte`
+          <Combobox value="test" on:change={console.log}>
+            <ComboboxInput on:change={NOOP} />
+            <ComboboxButton let:open let:disabled>{JSON.stringify({ open, disabled, value: "test" })}</ComboboxButton>
+            <ComboboxOptions>
+              <ComboboxOption value="a">Option A</ComboboxOption>
+              <ComboboxOption value="b">Option B</ComboboxOption>
+              <ComboboxOption value="c">Option C</ComboboxOption>
+            </ComboboxOptions>
+          </Combobox>
+        `);
+
+      assertComboboxButton({
+        state: ComboboxState.InvisibleUnmounted,
+        attributes: { id: "headlessui-combobox-button-2" },
+        textContent: JSON.stringify({
+          open: false,
+          disabled: false,
+          value: "test",
+        }),
+      });
+      assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+      await click(getComboboxButton());
+
+      assertComboboxButton({
+        state: ComboboxState.Visible,
+        attributes: { id: "headlessui-combobox-button-2" },
+        textContent: JSON.stringify({
+          open: true,
+          disabled: false,
+          value: "test",
+        }),
+      });
+      assertComboboxList({ state: ComboboxState.Visible });
+    })
+  );
+
+  it(
+    "should be possible to render a ComboboxButton using a slot prop and an `as` prop",
+    suppressConsoleLogs(async () => {
+      render(svelte`
+          <Combobox value="test" on:change={console.log}>
+            <ComboboxInput on:change={NOOP} />
+            <ComboboxButton as="div" role="button" let:open let:disabled>
+              {JSON.stringify({ open, disabled, value: "test" })}
+            </ComboboxButton>
+            <ComboboxOptions>
+              <ComboboxOption value="a">Option A</ComboboxOption>
+              <ComboboxOption value="b">Option B</ComboboxOption>
+              <ComboboxOption value="c">Option C</ComboboxOption>
+            </ComboboxOptions>
+          </Combobox>
+        `);
+
+      assertComboboxButton({
+        state: ComboboxState.InvisibleUnmounted,
+        attributes: { id: "headlessui-combobox-button-2" },
+        textContent: JSON.stringify({
+          open: false,
+          disabled: false,
+          value: "test",
+        }),
+      });
+      assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+      await click(getComboboxButton());
+
+      assertComboboxButton({
+        state: ComboboxState.Visible,
+        attributes: { id: "headlessui-combobox-button-2" },
+        textContent: JSON.stringify({
+          open: true,
+          disabled: false,
+          value: "test",
+        }),
+      });
+      assertComboboxList({ state: ComboboxState.Visible });
+    })
+  );
+
+  it(
+    "should be possible to render a ComboboxButton and a ComboboxLabel and see them linked together",
+    suppressConsoleLogs(async () => {
+      render(svelte`
+          <Combobox value="test" on:change={console.log}>
+            <ComboboxLabel>Label</ComboboxLabel>
+            <ComboboxInput on:change={NOOP} />
+            <ComboboxButton>Trigger</ComboboxButton>
+            <ComboboxOptions>
+              <ComboboxOption value="a">Option A</ComboboxOption>
+              <ComboboxOption value="b">Option B</ComboboxOption>
+              <ComboboxOption value="c">Option C</ComboboxOption>
+            </ComboboxOptions>
+          </Combobox>
+        `);
+
+      // TODO: Needed to make it similar to vue test implementation?
+      // await new Promise(requestAnimationFrame)
+
+      assertComboboxButton({
+        state: ComboboxState.InvisibleUnmounted,
+        attributes: { id: "headlessui-combobox-button-3" },
+      });
+      assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+      assertComboboxButtonLinkedWithComboboxLabel();
+    })
+  );
+
+  describe("`type` attribute", () => {
+    it('should set the `type` to "button" by default', async () => {
+      render(svelte`
+          <Combobox value={null} on:change={console.log}>
+            <ComboboxInput on:change={NOOP} />
+            <ComboboxButton>Trigger</ComboboxButton>
+          </Combobox>
+        `);
+
+      expect(getComboboxButton()).toHaveAttribute("type", "button");
+    });
+
+    it('should not set the `type` to "button" if it already contains a `type`', async () => {
+      render(svelte`
+          <Combobox value={null} on:change={console.log}>
+            <ComboboxInput on:change={NOOP} />
+            <ComboboxButton type="submit">Trigger</ComboboxButton>
+          </Combobox>
+        `);
+
+      expect(getComboboxButton()).toHaveAttribute("type", "submit");
+    });
+
+    it('should set the `type` to "button" when using the `as` prop which resolves to a "button"', async () => {
+      render(svelte`
+          <Combobox value={null} on:change={console.log}>
+            <ComboboxInput on:change={NOOP} />
+            <ComboboxButton as="button">Trigger</ComboboxButton>
+          </Combobox>
+        `);
+
+      expect(getComboboxButton()).toHaveAttribute("type", "button");
+    });
+
+    it('should not set the type if the "as" prop is not a "button"', async () => {
+      render(svelte`
+          <Combobox value={null} on:change={console.log}>
+            <ComboboxInput on:change={NOOP} />
+            <ComboboxButton as="div">Trigger</ComboboxButton>
+          </Combobox>
+        `);
+
+      expect(getComboboxButton()).not.toHaveAttribute("type");
+    });
+
+    it('should not set the `type` to "button" when using the `as` prop which resolves to a "div"', async () => {
+      render(svelte`
+          <Combobox value={null} on:change={console.log}>
+            <ComboboxInput on:change={NOOP} />
+            <ComboboxButton as="div">Trigger</ComboboxButton>
+          </Combobox>
+        `);
+
+      expect(getComboboxButton()).not.toHaveAttribute("type");
+    });
+  });
+});
+
+describe("ComboboxOptions", () => {
+  it(
+    "should be possible to render ComboboxOptions using a slot prop",
+    suppressConsoleLogs(async () => {
+      render(svelte`
+          <Combobox value="test" on:change={console.log}>
+            <ComboboxInput on:change={NOOP} />
+            <ComboboxButton>Trigger</ComboboxButton>
+            <ComboboxOptions let:open>              
+              <ComboboxOption value="a">
+                {JSON.stringify({open})}
+              </ComboboxOption>                
+            </ComboboxOptions>
+          </Combobox>
+        `);
+
+      assertComboboxButton({
+        state: ComboboxState.InvisibleUnmounted,
+        attributes: { id: "headlessui-combobox-button-2" },
+      });
+      assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+      await click(getComboboxButton());
+
+      assertComboboxButton({
+        state: ComboboxState.Visible,
+        attributes: { id: "headlessui-combobox-button-2" },
+      });
+      assertComboboxList({
+        state: ComboboxState.Visible,
+        textContent: JSON.stringify({ open: true }),
+      });
+      assertActiveElement(getComboboxInput());
+    })
+  );
+
+  it("should be possible to always render the ComboboxOptions if we provide it a `static` prop", () => {
+    render(svelte`
+        <Combobox value="test" on:change={console.log}>
+          <ComboboxInput on:change={NOOP} />
+          <ComboboxButton>Trigger</ComboboxButton>
+          <ComboboxOptions static>
+            <ComboboxOption value="a">Option A</ComboboxOption>
+            <ComboboxOption value="b">Option B</ComboboxOption>
+            <ComboboxOption value="c">Option C</ComboboxOption>
+          </ComboboxOptions>
+        </Combobox>
+      `);
+
+    // Let's verify that the Combobox is already there
+    expect(getComboboxInput()).not.toBe(null);
+  });
+
+  it("should be possible to use a different render strategy for the ComboboxOptions", async () => {
+    render(svelte`
+        <Combobox value="test" on:change={console.log}>
+          <ComboboxInput on:change={NOOP} />
+          <ComboboxButton>Trigger</ComboboxButton>
+          <ComboboxOptions unmount={false}>
+            <ComboboxOption value="a">Option A</ComboboxOption>
+            <ComboboxOption value="b">Option B</ComboboxOption>
+            <ComboboxOption value="c">Option C</ComboboxOption>
+          </ComboboxOptions>
+        </Combobox>
+      `);
+
+    assertComboboxList({ state: ComboboxState.InvisibleHidden });
+
+    // Let's open the Combobox, to see if it is not hidden anymore
+    await click(getComboboxButton());
+
+    assertComboboxList({ state: ComboboxState.Visible });
+  });
+});
+
+describe("ComboboxOption", () => {
+  it(
+    "should be possible to render a ComboboxOption using a slot prop",
+    suppressConsoleLogs(async () => {
+      render(svelte`
+          <Combobox value="test" on:change={console.log}>
+            <ComboboxInput on:change={NOOP} />
+            <ComboboxButton>Trigger</ComboboxButton>
+            <ComboboxOptions>
+              <ComboboxOption value="a" let:active let:selected let:disabled>{JSON.stringify({active, selected, disabled})}</ComboboxOption>
+            </ComboboxOptions>
+          </Combobox>
+        `);
+
+      assertComboboxButton({
+        state: ComboboxState.InvisibleUnmounted,
+        attributes: { id: "headlessui-combobox-button-2" },
+      });
+      assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+      await click(getComboboxButton());
+
+      assertComboboxButton({
+        state: ComboboxState.Visible,
+        attributes: { id: "headlessui-combobox-button-2" },
+      });
+      assertComboboxList({
+        state: ComboboxState.Visible,
+        textContent: JSON.stringify({
+          active: true,
+          selected: false,
+          disabled: false,
+        }),
+      });
+    })
+  );
+});
+
+it("should guarantee the order of DOM nodes when performing actions", async () => {
+  const { rerender } = render(svelte`
+    <script>        
+        let hide = false        
+    </script>
+
+    <Combobox value="test" on:change={console.log}>
+      <ComboboxInput on:change={NOOP} />
+      <ComboboxButton>Trigger</ComboboxButton>
+      <ComboboxOptions>
+        <ComboboxOption value="a">Option 1</ComboboxOption>
+        {#if !hide}
+          <ComboboxOption value="b">Option 2</ComboboxOption>
+        {/if}
+        <ComboboxOption value="c">Option 3</ComboboxOption>
+      </ComboboxOptions>
+    </Combobox>
+    `);
+
+  // Open the Combobox
+  await click(getByText("Trigger"));
+
+  rerender({hide: true}) // Remove Combobox.Option 2
+  await nextFrame()
+
+  rerender({hide: false}) // Re-add Combobox.Option 2
+  await nextFrame()
+
+  assertComboboxList({ state: ComboboxState.Visible });
+
+  let options = getComboboxOptions();
+
+  // Verify that the first combobox option is active
+  assertActiveComboboxOption(options[0]);
+
+  await press(Keys.ArrowDown);
+
+  // Verify that the second combobox option is active
+  assertActiveComboboxOption(options[1]);
+
+  await press(Keys.ArrowDown);
+
+  // Verify that the third combobox option is active
+  assertActiveComboboxOption(options[2]);
+});
+
+describe("Uncontrolled", () => {
+  it("should be possible to use in an uncontrolled way", async () => {
+    let handleSubmission = jest.fn();
+
+    render(svelte`        
+        <form
+          on:submit={(e) => {
+            e.preventDefault();
+            handleSubmission(
+              Object.fromEntries(new FormData(e.target))
+            );
+          }}
+        >
+          <Combobox name="assignee">
+            <ComboboxInput on:change={NOOP} />
+            <ComboboxButton>Trigger</ComboboxButton>
+            <ComboboxOptions>
+              <ComboboxOption value="alice">Alice</ComboboxOption>
+              <ComboboxOption value="bob">Bob</ComboboxOption>
+              <ComboboxOption value="charlie">Charlie</ComboboxOption>
+            </ComboboxOptions>
+          </Combobox>
+          <button id="submit">submit</button>
+        </form>
+      `);
+
+    await click(document.getElementById("submit"));
+
+    // No values
+    expect(handleSubmission).toHaveBeenLastCalledWith({});
+
+    // Open combobox
+    await click(getComboboxButton());
+
+    // Choose alice
+    await click(getComboboxOptions()[0]);
+
+    // Submit
+    await click(document.getElementById("submit"));
+
+    // Alice should be submitted
+    expect(handleSubmission).toHaveBeenLastCalledWith({ assignee: "alice" });
+
+    // Open combobox
+    await click(getComboboxButton());
+
+    // Choose charlie
+    await click(getComboboxOptions()[2]);
+
+    // Submit
+    await click(document.getElementById("submit"));
+
+    // Charlie should be submitted
+    expect(handleSubmission).toHaveBeenLastCalledWith({
+      assignee: "charlie",
+    });
+  });
+
+  it("should expose the value via the slot prop", async () => {
+    let handleSubmission = jest.fn();
+
+    let { getByTestId } = render(svelte`
+        <form
+          on:submit={(e) => {
+            e.preventDefault();
+            handleSubmission(
+              Object.fromEntries(new FormData(e.target))
+            );
+          }}
+        >
+          <Combobox name="assignee" let:value>            
+            <div data-testid="value">{value}</div>
+            <ComboboxInput on:change={NOOP} />
+            <ComboboxButton let:value>              
+              Trigger
+              <div data-testid="value-2">{value}</div>                
+            </ComboboxButton>
+            <ComboboxOptions>
+              <ComboboxOption value="alice">Alice</ComboboxOption>
+              <ComboboxOption value="bob">Bob</ComboboxOption>
+              <ComboboxOption value="charlie">Charlie</ComboboxOption>
+            </ComboboxOptions>              
+          </Combobox>
+          <button id="submit">submit</button>
+        </form>
+      `);
+
+    await click(document.getElementById("submit"));
+
+    // No values
+    expect(handleSubmission).toHaveBeenLastCalledWith({});
+
+    // Open combobox
+    await click(getComboboxButton());
+
+    // Choose alice
+    await click(getComboboxOptions()[0]);
+    expect(getByTestId("value")).toHaveTextContent("alice");
+    expect(getByTestId("value-2")).toHaveTextContent("alice");
+
+    // Submit
+    await click(document.getElementById("submit"));
+
+    // Alice should be submitted
+    expect(handleSubmission).toHaveBeenLastCalledWith({ assignee: "alice" });
+
+    // Open combobox
+    await click(getComboboxButton());
+
+    // Choose charlie
+    await click(getComboboxOptions()[2]);
+    expect(getByTestId("value")).toHaveTextContent("charlie");
+    expect(getByTestId("value-2")).toHaveTextContent("charlie");
+
+    // Submit
+    await click(document.getElementById("submit"));
+
+    // Charlie should be submitted
+    expect(handleSubmission).toHaveBeenLastCalledWith({
+      assignee: "charlie",
+    });
+  });
+
+  it("should be possible to provide a default value", async () => {
+    let handleSubmission = jest.fn();
+
+    render(svelte`
+        <form
+          on:submit={(e) => {
+            e.preventDefault();
+            handleSubmission(
+              Object.fromEntries(new FormData(e.target))
+            );
+          }}
+        >
+          <Combobox name="assignee" defaultValue="bob">
+            <ComboboxInput on:change={NOOP} />
+            <ComboboxButton>Trigger</ComboboxButton>
+            <ComboboxOptions>
+              <ComboboxOption value="alice">Alice</ComboboxOption>
+              <ComboboxOption value="bob">Bob</ComboboxOption>
+              <ComboboxOption value="charlie">Charlie</ComboboxOption>
+            </ComboboxOptions>
+          </Combobox>
+          <button id="submit">submit</button>
+        </form>
+      `);
+
+    await click(document.getElementById("submit"));
+
+    // Bob is the defaultValue
+    expect(handleSubmission).toHaveBeenLastCalledWith({ assignee: "bob" });
+
+    // Open combobox
+    await click(getComboboxButton());
+
+    // Choose alice
+    await click(getComboboxOptions()[0]);
+
+    // Submit
+    await click(document.getElementById("submit"));
+
+    // Alice should be submitted
+    expect(handleSubmission).toHaveBeenLastCalledWith({ assignee: "alice" });
+  });
+
+  it("should still call the on:change listeners when choosing new values", async () => {
+    let handleChange = jest.fn();
+
+    render(svelte`
+        <Combobox name="assignee" on:change={(e) => { handleChange(e.detail) }}>
+          <ComboboxInput on:change={NOOP} />
+          <ComboboxButton>Trigger</ComboboxButton>
+          <ComboboxOptions>
+            <ComboboxOption value="alice">Alice</ComboboxOption>
+            <ComboboxOption value="bob">Bob</ComboboxOption>
+            <ComboboxOption value="charlie">Charlie</ComboboxOption>
+          </ComboboxOptions>
+        </Combobox>
+      `);
+
+    // Open combobox
+    await click(getComboboxButton());
+
+    // Choose alice
+    await click(getComboboxOptions()[0]);
+
+    // Open combobox
+    await click(getComboboxButton());
+
+    // Choose bob
+    await click(getComboboxOptions()[1]);
+
+    // Change handler should have been called twice
+    expect(handleChange).toHaveBeenNthCalledWith(1, "alice");
+    expect(handleChange).toHaveBeenNthCalledWith(2, "bob");
+  });
+});
+
+describe("Rendering composition", () => {
+  it(
+    "should be possible to conditionally render classes",
+    suppressConsoleLogs(async () => {
+      render(svelte`
+        <Combobox value="test" on:change={console.log}>
+          <ComboboxInput on:change={NOOP} />
+          <ComboboxButton>Trigger</ComboboxButton>
+          <ComboboxOptions>
+            <ComboboxOption value="a" 
+              let:active 
+              let:selected 
+              let:disabled 
+              class={(info) => JSON.stringify(info)}
+            >
+              Option A
+            </ComboboxOption>
+            <ComboboxOption
+              value="b"
+              disabled={true}
+              let:active 
+              let:selected 
+              let:disabled
+              class={(info) => JSON.stringify(info)}
+            >
+              Option B
+            </ComboboxOption>
+            <ComboboxOption value="c" class="no-special-treatment">
+              Option C
+            </ComboboxOption>
+          </ComboboxOptions>
+        </Combobox>
+      `);
+
+      await nextFrame()
+
+      assertComboboxButton({
+        state: ComboboxState.InvisibleUnmounted,
+        attributes: { id: "headlessui-combobox-button-2" },
+      });
+      assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+      // Open Combobox
+      await click(getComboboxButton());
+
+      let options = getComboboxOptions();
+
+      // Verify that the first combobox option is active
+      assertActiveComboboxOption(options[0]);
+
+      // Verify correct classNames
+      expect("" + options[0].classList).toEqual(
+        JSON.stringify({ active: true, selected: false, disabled: false })
+      );
+      expect("" + options[1].classList).toEqual(
+        JSON.stringify({ active: false, selected: false, disabled: true })
+      );
+      expect("" + options[2].classList).toEqual("no-special-treatment");
+
+      // Let's go down, this should go to the third option since the second option is disabled!
+      await press(Keys.ArrowDown);
+
+      // Verify the classNames
+      expect("" + options[0].classList).toEqual(
+        JSON.stringify({ active: false, selected: false, disabled: false })
+      );
+      expect("" + options[1].classList).toEqual(
+        JSON.stringify({ active: false, selected: false, disabled: true })
+      );
+      expect("" + options[2].classList).toEqual("no-special-treatment");
+
+      // Double check that the last option is the active one
+      assertActiveComboboxOption(options[2]);
+    })
+  );
+
+  it(
+    "should be possible to swap the Combobox option with a button for example",
+    suppressConsoleLogs(async () => {
+      render(svelte`
+        <Combobox value="test" on:change={console.log}>
+          <ComboboxInput on:change={NOOP} />
+          <ComboboxButton>Trigger</ComboboxButton>
+          <ComboboxOptions>
+            <ComboboxOption as="button" value="a">
+              Option A
+            </ComboboxOption>
+            <ComboboxOption as="button" value="b">
+              Option B
+            </ComboboxOption>
+            <ComboboxOption as="button" value="c">
+              Option C
+            </ComboboxOption>
+          </ComboboxOptions>
+        </Combobox>
+      `);
+
+      assertComboboxButton({
+        state: ComboboxState.InvisibleUnmounted,
+        attributes: { id: "headlessui-combobox-button-2" },
+      });
+      assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+      // Open Combobox
+      await click(getComboboxButton());
+
+      // Verify options are buttons now
+      getComboboxOptions().forEach((option) =>
+        assertComboboxOption(option, { tag: "button" })
+      );
+    })
+  );
+
+  it(
+    "should mark all the elements between ComboboxOptions and ComboboxOption with role none",
+    suppressConsoleLogs(async () => {
+      render(svelte`
+        <Combobox value="test" on:change={console.log}>
+          <ComboboxInput on:change={NOOP} />
+          <ComboboxButton>Button</ComboboxButton>
+          <div class="outer">
+            <ComboboxOptions>
+              <div class="inner py-1">
+                <ComboboxOption value="a">Option A</ComboboxOption>
+                <ComboboxOption value="b">Option B</ComboboxOption>
+              </div>
+              <div class="inner py-1">
+                <ComboboxOption value="c">Option C</ComboboxOption>
+                <ComboboxOption value="d">
+                  <div>
+                    <div class="outer">Option D</div>
+                  </div>
+                </ComboboxOption>
+              </div>
+              <div class="inner py-1">
+                <form class="inner">
+                  <ComboboxOption value="e">Option E</ComboboxOption>
+                </form>
+              </div>
+            </ComboboxOptions>
+          </div>
+        </Combobox>
+      `);
+
+      // Open combobox
+      await click(getComboboxButton());
+
+      expect.hasAssertions();
+
+      document.querySelectorAll(".outer").forEach((element) => {
+        expect(element).not.toHaveAttribute("role", "none");
+      });
+
+      document.querySelectorAll(".inner").forEach((element) => {
+        expect(element).toHaveAttribute("role", "none");
+      });
+    })
+  );
+});
+
+// describe("Composition", () => { 
+
+//   it(
+//     "should be possible to wrap the ComboboxOptions with a Transition component",
+//     suppressConsoleLogs(async () => {
+//       let orderFn = jest.fn();
+//       render(svelte`
+//         <Combobox value="test" on:change={console.log}>          
+//           <TransitionDebug name="Combobox" fn={orderFn} />
+//           <ComboboxInput on:change={NOOP} />
+//           <ComboboxButton>Trigger</ComboboxButton>          
+//           <Transition>                        
+//             <TransitionDebug name="Transition" fn={orderFn} />
+//             <ComboboxOptions>
+//               <ComboboxOption value="a" let:active let:selected let:disabled>                
+//                 <TransitionDebug name="ComboboxOption" fn={orderFn} />
+//                 {JSON.stringify({active, selected, disabled})}                                  
+//               </ComboboxOption>
+//             </ComboboxOptions>
+//           </Transition>
+//         </Combobox>
+//       `);
+
+//       assertComboboxButton({
+//         state: ComboboxState.InvisibleUnmounted,
+//         attributes: { id: "headlessui-combobox-button-2" },
+//       });
+//       assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+//       await click(getComboboxButton());
+
+//       assertComboboxButton({
+//         state: ComboboxState.Visible,
+//         attributes: { id: "headlessui-combobox-button-2" },
+//       });
+//       assertComboboxList({
+//         state: ComboboxState.Visible,
+//         textContent: JSON.stringify({
+//           active: true,
+//           selected: false,
+//           disabled: false,
+//         }),
+//       });
+
+//       await click(getComboboxButton());
+
+//       // Verify that we tracked the `mounts` and `unmounts` in the correct order
+//       expect(orderFn.mock.calls).toEqual([
+//         ["Mounting - Combobox"],
+//         ["Mounting - Transition"],
+//         ["Mounting - ComboboxOption"],
+//         ["Unmounting - Transition"],
+//         ["Unmounting - ComboboxOption"],
+//       ]);
+//     })
+//   );
+// });
+
+describe("Keyboard interactions", () => {
+  describe("Button", () => {
+    describe("`Enter` key", () => {
+      it(
+        "should be possible to open the combobox with Enter",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value="test" on:change={console.log}>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                <ComboboxOption value="a">Option A</ComboboxOption>
+                <ComboboxOption value="b">Option B</ComboboxOption>
+                <ComboboxOption value="c">Option C</ComboboxOption>
+              </ComboboxOptions>
+            </Combobox>
+          `);
+
+          assertComboboxButton({
+            state: ComboboxState.InvisibleUnmounted,
+            attributes: { id: "headlessui-combobox-button-2" },
+          });
+          assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+          // Focus the button
+          await focus(getComboboxButton());
+
+          // Open combobox
+          await press(Keys.Enter);
+
+          await nextFrame()
+
+          // Verify we moved focus to the input field
+          assertActiveElement(getComboboxInput());
+
+          // Verify it is visible
+          assertComboboxButton({ state: ComboboxState.Visible });
+          assertComboboxList({
+            state: ComboboxState.Visible,
+            attributes: { id: "headlessui-combobox-options-3" },
+          });
+          assertActiveElement(getComboboxInput());
+          assertComboboxButtonLinkedWithCombobox();
+
+          // Verify we have combobox options
+          let options = getComboboxOptions();
+          expect(options).toHaveLength(3);
+          options.forEach((option) =>
+            assertComboboxOption(option, { selected: false })
+          );
+
+          assertActiveComboboxOption(options[0]);
+          assertNoSelectedComboboxOption();
+        })
+      );
+
+      it(
+        "should not be possible to open the combobox with Enter when the button is disabled",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value={undefined} on:change={console.log} disabled>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                <ComboboxOption value="a">Option A</ComboboxOption>
+                <ComboboxOption value="b">Option B</ComboboxOption>
+                <ComboboxOption value="c">Option C</ComboboxOption>
+              </ComboboxOptions>
+            </Combobox>
+          `);
+
+          assertComboboxButton({
+            state: ComboboxState.InvisibleUnmounted,
+            attributes: { id: "headlessui-combobox-button-2" },
+          });
+          assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+          // Try to focus the button
+          await focus(getComboboxButton());
+
+          // Try to open the combobox
+          await press(Keys.Enter);
+
+          // Verify it is still closed
+          assertComboboxButton({
+            state: ComboboxState.InvisibleUnmounted,
+            attributes: { id: "headlessui-combobox-button-2" },
+          });
+          assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+        })
+      );
+
+      it(
+        "should be possible to open the combobox with Enter, and focus the selected option",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value="b" on:change={console.log}>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                <ComboboxOption value="a">Option A</ComboboxOption>
+                <ComboboxOption value="b">Option B</ComboboxOption>
+                <ComboboxOption value="c">Option C</ComboboxOption>
+              </ComboboxOptions>
+            </Combobox>
+          `);
+
+          assertComboboxButton({
+            state: ComboboxState.InvisibleUnmounted,
+            attributes: { id: "headlessui-combobox-button-2" },
+          });
+          assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+          // Focus the button
+          await focus(getComboboxButton());
+
+          // Open combobox
+          await press(Keys.Enter);
+
+          // Verify we moved focus to the input field
+          assertActiveElement(getComboboxInput());
+
+          // Verify it is visible
+          assertComboboxButton({ state: ComboboxState.Visible });
+          assertComboboxList({
+            state: ComboboxState.Visible,
+            attributes: { id: "headlessui-combobox-options-3" },
+          });
+          assertActiveElement(getComboboxInput());
+          assertComboboxButtonLinkedWithCombobox();
+
+          // Verify we have combobox options
+          let options = getComboboxOptions();
+          expect(options).toHaveLength(3);
+          options.forEach((option, i) =>
+            assertComboboxOption(option, { selected: i === 1 })
+          );
+
+          // Verify that the second combobox option is active (because it is already selected)
+          assertActiveComboboxOption(options[1]);
+        })
+      );
+
+      it(
+        "should be possible to open the combobox with Enter, and focus the selected option (when using the `hidden` render strategy)",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value="b" on:change={console.log}>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions unmount={false}>
+                <ComboboxOption value="a">Option A</ComboboxOption>
+                <ComboboxOption value="b">Option B</ComboboxOption>
+                <ComboboxOption value="c">Option C</ComboboxOption>
+              </ComboboxOptions>
+            </Combobox>
+          `);
+
+          assertComboboxButton({
+            state: ComboboxState.InvisibleHidden,
+            attributes: { id: "headlessui-combobox-button-2" },
+          });
+          assertComboboxList({ state: ComboboxState.InvisibleHidden });
+
+          // Focus the button
+          await focus(getComboboxButton());
+
+          // Open combobox
+          await press(Keys.Enter);
+
+          // Verify we moved focus to the input field
+          assertActiveElement(getComboboxInput());
+
+          // Verify it is visible
+          assertComboboxButton({ state: ComboboxState.Visible });
+          assertComboboxList({
+            state: ComboboxState.Visible,
+            attributes: { id: "headlessui-combobox-options-3" },
+          });
+          assertActiveElement(getComboboxInput());
+          assertComboboxButtonLinkedWithCombobox();
+
+          let options = getComboboxOptions();
+
+          // Hover over Option A
+          await mouseMove(options[0]);
+
+          // Verify that Option A is active
+          assertActiveComboboxOption(options[0]);
+
+          // Verify that Option B is still selected
+          assertComboboxOption(options[1], { selected: true });
+
+          // Close/Hide the combobox
+          await press(Keys.Escape);
+
+          // Re-open the combobox
+          await click(getComboboxButton());
+
+          // Verify we have combobox options
+          expect(options).toHaveLength(3);
+          options.forEach((option, i) =>
+            assertComboboxOption(option, { selected: i === 1 })
+          );
+
+          // Verify that the second combobox option is active (because it is already selected)
+          assertActiveComboboxOption(options[1]);
+        })
+      );
+
+      it(
+        "should be possible to open the combobox with Enter, and focus the selected option (with a list of objects)",
+        suppressConsoleLogs(async () => {          
+          render(svelte`
+            <script>
+            let myOptions = [
+              { id: "a", name: "Option A" },
+              { id: "b", name: "Option B" },
+              { id: "c", name: "Option C" },
+            ];
+            let selectedOption = myOptions[1];
+            </script>
+
+            <Combobox value={selectedOption} on:change={console.log}>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                {#each myOptions as myOption}                
+                  <ComboboxOption value={myOption}>
+                    {myOption.name}
+                  </ComboboxOption>
+                {/each}
+              </ComboboxOptions>
+            </Combobox>
+          `);
+
+          assertComboboxButton({
+            state: ComboboxState.InvisibleUnmounted,
+            attributes: { id: "headlessui-combobox-button-2" },
+          });
+          assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+          // Focus the button
+          await focus(getComboboxButton());
+
+          // Open combobox
+          await press(Keys.Enter);
+
+          // Verify we moved focus to the input field
+          assertActiveElement(getComboboxInput());
+
+          // Verify it is visible
+          assertComboboxButton({ state: ComboboxState.Visible });
+          assertComboboxList({
+            state: ComboboxState.Visible,
+            attributes: { id: "headlessui-combobox-options-3" },
+          });
+          assertActiveElement(getComboboxInput());
+          assertComboboxButtonLinkedWithCombobox();
+
+          // Verify we have combobox options
+          let options = getComboboxOptions();
+          expect(options).toHaveLength(3);
+          options.forEach((option, i) =>
+            assertComboboxOption(option, { selected: i === 1 })
+          );
+
+          // Verify that the second combobox option is active (because it is already selected)
+          assertActiveComboboxOption(options[1]);
+        })
+      );
+
+      it(
+        "should have no active combobox option when there are no combobox options at all",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value="test" on:change={console.log}>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions />
+            </Combobox>
+          `);
+
+          assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+          // Focus the button
+          await focus(getComboboxButton());
+
+          // Open combobox
+          await press(Keys.Enter);
+
+          // Verify we moved focus to the input field
+          assertActiveElement(getComboboxInput());
+
+          assertComboboxList({ state: ComboboxState.Visible });
+          assertActiveElement(getComboboxInput());
+
+          assertNoActiveComboboxOption();
+        })
+      );
+    });
+
+    describe("`Space` key", () => {
+      it(
+        "should be possible to open the combobox with Space",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value="test" on:change={console.log}>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                <ComboboxOption value="a">Option A</ComboboxOption>
+                <ComboboxOption value="b">Option B</ComboboxOption>
+                <ComboboxOption value="c">Option C</ComboboxOption>
+              </ComboboxOptions>
+            </Combobox>
+          `);
+
+          assertComboboxButton({
+            state: ComboboxState.InvisibleUnmounted,
+            attributes: { id: "headlessui-combobox-button-2" },
+          });
+          assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+          // Focus the button
+          await focus(getComboboxButton());
+
+          // Open combobox
+          await press(Keys.Space);
+
+          // Verify we moved focus to the input field
+          assertActiveElement(getComboboxInput());
+
+          // Verify it is visible
+          assertComboboxButton({ state: ComboboxState.Visible });
+          assertComboboxList({
+            state: ComboboxState.Visible,
+            attributes: { id: "headlessui-combobox-options-3" },
+          });
+          assertActiveElement(getComboboxInput());
+          assertComboboxButtonLinkedWithCombobox();
+
+          // Verify we have combobox options
+          let options = getComboboxOptions();
+          expect(options).toHaveLength(3);
+          options.forEach((option) => assertComboboxOption(option));
+          assertActiveComboboxOption(options[0]);
+        })
+      );
+
+      it(
+        "should not be possible to open the combobox with Space when the button is disabled",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value={undefined} on:change={console.log} disabled>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                <ComboboxOption value="a">Option A</ComboboxOption>
+                <ComboboxOption value="b">Option B</ComboboxOption>
+                <ComboboxOption value="c">Option C</ComboboxOption>
+              </ComboboxOptions>
+            </Combobox>
+          `);
+
+          assertComboboxButton({
+            state: ComboboxState.InvisibleUnmounted,
+            attributes: { id: "headlessui-combobox-button-2" },
+          });
+          assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+          // Focus the button
+          await focus(getComboboxButton());
+
+          // Try to open the combobox
+          await press(Keys.Space);
+
+          // Verify it is still closed
+          assertComboboxButton({
+            state: ComboboxState.InvisibleUnmounted,
+            attributes: { id: "headlessui-combobox-button-2" },
+          });
+          assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+        })
+      );
+
+      it(
+        "should be possible to open the combobox with Space, and focus the selected option",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value="b" on:change={console.log}>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                <ComboboxOption value="a">Option A</ComboboxOption>
+                <ComboboxOption value="b">Option B</ComboboxOption>
+                <ComboboxOption value="c">Option C</ComboboxOption>
+              </ComboboxOptions>
+            </Combobox>
+          `);
+
+          assertComboboxButton({
+            state: ComboboxState.InvisibleUnmounted,
+            attributes: { id: "headlessui-combobox-button-2" },
+          });
+          assertComboboxList({
+            state: ComboboxState.InvisibleUnmounted,
+          });
+
+          // Focus the button
+          await focus(getComboboxButton());
+
+          // Open combobox
+          await press(Keys.Space);
+
+          // Verify it is visible
+          assertComboboxButton({ state: ComboboxState.Visible });
+          assertComboboxList({
+            state: ComboboxState.Visible,
+            attributes: { id: "headlessui-combobox-options-3" },
+          });
+          assertActiveElement(getComboboxInput());
+          assertComboboxButtonLinkedWithCombobox();
+
+          // Verify we have combobox options
+          let options = getComboboxOptions();
+          expect(options).toHaveLength(3);
+          options.forEach((option, i) =>
+            assertComboboxOption(option, { selected: i === 1 })
+          );
+
+          // Verify that the second combobox option is active (because it is already selected)
+          assertActiveComboboxOption(options[1]);
+        })
+      );
+
+      it(
+        "should have no active combobox option when there are no combobox options at all",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value="test" on:change={console.log}>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions />
+            </Combobox>
+          `);
+
+          assertComboboxList({
+            state: ComboboxState.InvisibleUnmounted,
+          });
+
+          // Focus the button
+          await focus(getComboboxButton());
+
+          // Open combobox
+          await press(Keys.Space);
+          assertComboboxList({ state: ComboboxState.Visible });
+          assertActiveElement(getComboboxInput());
+
+          assertNoActiveComboboxOption();
+        })
+      );
+
+      it(
+        "should have no active combobox option upon Space key press, when there are no non-disabled combobox options",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value="test" on:change={console.log}>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                <ComboboxOption disabled value="a">
+                  Option A
+                </ComboboxOption>
+                <ComboboxOption disabled value="b">
+                  Option B
+                </ComboboxOption>
+                <ComboboxOption disabled value="c">
+                  Option C
+                </ComboboxOption>
+              </ComboboxOptions>
+            </Combobox>
+          `);
+
+          assertComboboxButton({
+            state: ComboboxState.InvisibleUnmounted,
+            attributes: { id: "headlessui-combobox-button-2" },
+          });
+          assertComboboxList({
+            state: ComboboxState.InvisibleUnmounted,
+          });
+
+          // Focus the button
+          await focus(getComboboxButton());
+
+          // Open combobox
+          await press(Keys.Space);
+
+          assertNoActiveComboboxOption();
+        })
+      );
+    });
+
+    describe("`Escape` key", () => {
+      it(
+        "should be possible to close an open combobox with Escape",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value="test" on:change={console.log}>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                <ComboboxOption value="a">Option A</ComboboxOption>
+                <ComboboxOption value="b">Option B</ComboboxOption>
+                <ComboboxOption value="c">Option C</ComboboxOption>
+              </ComboboxOptions>
+            </Combobox>
+          `);
+
+          // Open combobox
+          await click(getComboboxButton());
+
+          // Verify it is visible
+          assertComboboxButton({ state: ComboboxState.Visible });
+          assertComboboxList({
+            state: ComboboxState.Visible,
+            attributes: { id: "headlessui-combobox-options-3" },
+          });
+          assertActiveElement(getComboboxInput());
+          assertComboboxButtonLinkedWithCombobox();
+
+          // Re-focus the button
+          await focus(getComboboxButton());
+          assertActiveElement(getComboboxButton());
+
+          // Close combobox
+          await press(Keys.Escape);
+
+          // Verify it is closed
+          assertComboboxButton({ state: ComboboxState.InvisibleUnmounted });
+          assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+          // Verify the input is focused again
+          assertActiveElement(getComboboxInput());
+        })
+      );
+
+      it(
+        "should not propagate the Escape event when the combobox is open",
+        suppressConsoleLogs(async () => {
+          let handleKeyDown = jest.fn();
+          render(svelte`
+            <div on:keydown={handleKeyDown}>
+              <Combobox value="test" on:change={console.log}>
+                <ComboboxInput on:change={NOOP} />
+                <ComboboxButton>Trigger</ComboboxButton>
+                <ComboboxOptions>
+                  <ComboboxOption value="a">Option A</ComboboxOption>
+                  <ComboboxOption value="b">Option B</ComboboxOption>
+                  <ComboboxOption value="c">Option C</ComboboxOption>
+                </ComboboxOptions>
+              </Combobox>
+            </div>
+          `);
+
+          // Open combobox
+          await click(getComboboxButton());
+
+          // Close combobox
+          await press(Keys.Escape);
+
+          // We should never see the Escape event
+          expect(handleKeyDown).toHaveBeenCalledTimes(0);
+        })
+      );
+
+      it(
+        "should propagate the Escape event when the combobox is closed",
+        suppressConsoleLogs(async () => {
+          let handleKeyDown = jest.fn();
+          render(svelte`
+            <div on:keydown={handleKeyDown}>
+              <Combobox value="test" on:change={console.log}>
+                <ComboboxInput on:change={NOOP} />
+                <ComboboxButton>Trigger</ComboboxButton>
+                <ComboboxOptions>
+                  <ComboboxOption value="a">Option A</ComboboxOption>
+                  <ComboboxOption value="b">Option B</ComboboxOption>
+                  <ComboboxOption value="c">Option C</ComboboxOption>
+                </ComboboxOptions>
+              </Combobox>
+            </div>
+          `);
+
+          // Focus the input field
+          await focus(getComboboxInput());
+
+          // Close combobox
+          await press(Keys.Escape);
+
+          // We should never see the Escape event
+          expect(handleKeyDown).toHaveBeenCalledTimes(1);
+        })
+      );
+    });
+
+    describe("`ArrowDown` key", () => {
+      it(
+        "should be possible to open the combobox with ArrowDown",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value="test" on:change={console.log}>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                <ComboboxOption value="a">Option A</ComboboxOption>
+                <ComboboxOption value="b">Option B</ComboboxOption>
+                <ComboboxOption value="c">Option C</ComboboxOption>
+              </ComboboxOptions>
+            </Combobox>
+          `);
+
+          assertComboboxButton({
+            state: ComboboxState.InvisibleUnmounted,
+            attributes: { id: "headlessui-combobox-button-2" },
+          });
+          assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+          // Focus the button
+          await focus(getComboboxButton());
+
+          // Open combobox
+          await press(Keys.ArrowDown);
+
+          // Verify it is visible
+          assertComboboxButton({ state: ComboboxState.Visible });
+          assertComboboxList({
+            state: ComboboxState.Visible,
+            attributes: { id: "headlessui-combobox-options-3" },
+          });
+          assertActiveElement(getComboboxInput());
+          assertComboboxButtonLinkedWithCombobox();
+
+          // Verify we have combobox options
+          let options = getComboboxOptions();
+          expect(options).toHaveLength(3);
+          options.forEach((option) => assertComboboxOption(option));
+
+          // Verify that the first combobox option is active
+          assertActiveComboboxOption(options[0]);
+        })
+      );
+
+      it(
+        "should not be possible to open the combobox with ArrowDown when the button is disabled",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value={undefined} on:change={console.log} disabled>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                <ComboboxOption value="a">Option A</ComboboxOption>
+                <ComboboxOption value="b">Option B</ComboboxOption>
+                <ComboboxOption value="c">Option C</ComboboxOption>
+              </ComboboxOptions>
+            </Combobox>
+          `);
+
+          assertComboboxButton({
+            state: ComboboxState.InvisibleUnmounted,
+            attributes: { id: "headlessui-combobox-button-2" },
+          });
+          assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+          // Focus the button
+          await focus(getComboboxButton());
+
+          // Try to open the combobox
+          await press(Keys.ArrowDown);
+
+          // Verify it is still closed
+          assertComboboxButton({
+            state: ComboboxState.InvisibleUnmounted,
+            attributes: { id: "headlessui-combobox-button-2" },
+          });
+          assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+        })
+      );
+
+      it(
+        "should be possible to open the combobox with ArrowDown, and focus the selected option",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value="b" on:change={console.log}>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                <ComboboxOption value="a">Option A</ComboboxOption>
+                <ComboboxOption value="b">Option B</ComboboxOption>
+                <ComboboxOption value="c">Option C</ComboboxOption>
+              </ComboboxOptions>
+            </Combobox>
+          `);
+
+          assertComboboxButton({
+            state: ComboboxState.InvisibleUnmounted,
+            attributes: { id: "headlessui-combobox-button-2" },
+          });
+          assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+          // Focus the button
+          await focus(getComboboxButton());
+
+          // Open combobox
+          await press(Keys.ArrowDown);
+
+          // Verify it is visible
+          assertComboboxButton({ state: ComboboxState.Visible });
+          assertComboboxList({
+            state: ComboboxState.Visible,
+            attributes: { id: "headlessui-combobox-options-3" },
+          });
+          assertActiveElement(getComboboxInput());
+          assertComboboxButtonLinkedWithCombobox();
+
+          // Verify we have combobox options
+          let options = getComboboxOptions();
+          expect(options).toHaveLength(3);
+          options.forEach((option, i) =>
+            assertComboboxOption(option, { selected: i === 1 })
+          );
+
+          // Verify that the second combobox option is active (because it is already selected)
+          assertActiveComboboxOption(options[1]);
+        })
+      );
+
+      it(
+        "should have no active combobox option when there are no combobox options at all",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value="test" on:change={console.log}>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions />
+            </Combobox>
+          `);
+
+          assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+          // Focus the button
+          await focus(getComboboxButton());
+
+          // Open combobox
+          await press(Keys.ArrowDown);
+          assertComboboxList({ state: ComboboxState.Visible });
+          assertActiveElement(getComboboxInput());
+
+          assertNoActiveComboboxOption();
+        })
+      );
+    });
+
+    describe("`ArrowUp` key", () => {
+      it(
+        "should be possible to open the combobox with ArrowUp and the last option should be active",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value={undefined} on:change={console.log}>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                <ComboboxOption value="a">Option A</ComboboxOption>
+                <ComboboxOption value="b">Option B</ComboboxOption>
+                <ComboboxOption value="c">Option C</ComboboxOption>
+              </ComboboxOptions>
+            </Combobox>
+          `);
+
+          assertComboboxButton({
+            state: ComboboxState.InvisibleUnmounted,
+            attributes: { id: "headlessui-combobox-button-2" },
+          });
+          assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+          // Focus the button
+          await focus(getComboboxButton());
+
+          // Open combobox
+          await press(Keys.ArrowUp);
+
+          // Verify it is visible
+          assertComboboxButton({ state: ComboboxState.Visible });
+          assertComboboxList({
+            state: ComboboxState.Visible,
+            attributes: { id: "headlessui-combobox-options-3" },
+          });
+          assertActiveElement(getComboboxInput());
+          assertComboboxButtonLinkedWithCombobox();
+
+          // Verify we have combobox options
+          let options = getComboboxOptions();
+          expect(options).toHaveLength(3);
+          options.forEach((option) => assertComboboxOption(option));
+
+          // ! ALERT: The LAST option should now be active
+          assertActiveComboboxOption(options[2]);
+        })
+      );
+
+      it(
+        "should not be possible to open the combobox with ArrowUp and the last option should be active when the button is disabled",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value={undefined} on:change={console.log} disabled>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                <ComboboxOption value="a">Option A</ComboboxOption>
+                <ComboboxOption value="b">Option B</ComboboxOption>
+                <ComboboxOption value="c">Option C</ComboboxOption>
+              </ComboboxOptions>
+            </Combobox>
+          `);
+
+          assertComboboxButton({
+            state: ComboboxState.InvisibleUnmounted,
+            attributes: { id: "headlessui-combobox-button-2" },
+          });
+          assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+          // Focus the button
+          await focus(getComboboxButton());
+
+          // Try to open the combobox
+          await press(Keys.ArrowUp);
+
+          // Verify it is still closed
+          assertComboboxButton({
+            state: ComboboxState.InvisibleUnmounted,
+            attributes: { id: "headlessui-combobox-button-2" },
+          });
+          assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+        })
+      );
+
+      it(
+        "should be possible to open the combobox with ArrowUp, and focus the selected option",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value="b" on:change={console.log}>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                <ComboboxOption value="a">Option A</ComboboxOption>
+                <ComboboxOption value="b">Option B</ComboboxOption>
+                <ComboboxOption value="c">Option C</ComboboxOption>
+              </ComboboxOptions>
+            </Combobox>
+          `);
+
+          assertComboboxButton({
+            state: ComboboxState.InvisibleUnmounted,
+            attributes: { id: "headlessui-combobox-button-2" },
+          });
+          assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+          // Focus the button
+          await focus(getComboboxButton());
+
+          // Open combobox
+          await press(Keys.ArrowUp);
+
+          // Verify it is visible
+          assertComboboxButton({ state: ComboboxState.Visible });
+          assertComboboxList({
+            state: ComboboxState.Visible,
+            attributes: { id: "headlessui-combobox-options-3" },
+          });
+          assertActiveElement(getComboboxInput());
+          assertComboboxButtonLinkedWithCombobox();
+
+          // Verify we have combobox options
+          let options = getComboboxOptions();
+          expect(options).toHaveLength(3);
+          options.forEach((option, i) =>
+            assertComboboxOption(option, { selected: i === 1 })
+          );
+
+          // Verify that the second combobox option is active (because it is already selected)
+          assertActiveComboboxOption(options[1]);
+        })
+      );
+
+      it(
+        "should have no active combobox option when there are no combobox options at all",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value="test" on:change={console.log}>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions />
+            </Combobox>
+          `);
+
+          assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+          // Focus the button
+          await focus(getComboboxButton());
+
+          // Open combobox
+          await press(Keys.ArrowUp);
+          assertComboboxList({ state: ComboboxState.Visible });
+          assertActiveElement(getComboboxInput());
+
+          assertNoActiveComboboxOption();
+        })
+      );
+
+      it(
+        "should be possible to use ArrowUp to navigate the combobox options and jump to the first non-disabled one",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value={undefined} on:change={console.log}>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                <ComboboxOption value="a">Option A</ComboboxOption>
+                <ComboboxOption disabled value="b">
+                  Option B
+                </ComboboxOption>
+                <ComboboxOption disabled value="c">
+                  Option C
+                </ComboboxOption>
+              </ComboboxOptions>
+            </Combobox>
+          `);
+
+          assertComboboxButton({
+            state: ComboboxState.InvisibleUnmounted,
+            attributes: { id: "headlessui-combobox-button-2" },
+          });
+          assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+          // Focus the button
+          await focus(getComboboxButton());
+
+          // Open combobox
+          await press(Keys.ArrowUp);
+
+          // Verify we have combobox options
+          let options = getComboboxOptions();
+          expect(options).toHaveLength(3);
+          options.forEach((option) => assertComboboxOption(option));
+          assertActiveComboboxOption(options[0]);
+        })
+      );
+    });
+  });
+
+  describe("`Backspace` key", () => {
+    it(
+      "should reset the value when the last character is removed, when in `nullable` mode",
+      suppressConsoleLogs(async () => {
+        let handleChange = jest.fn();
+
+        render(svelte`
+        <script>
+          let value = "bob"
+          let query = ""
+        </script>
+        <Combobox
+              value={value}
+              on:change={(event) => {
+                value = event.detail
+                handleChange(event.detail);
+              }}
+              nullable
+            >
+              <ComboboxInput
+                on:change={(event) => query=(event.target.value)}
+              />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                <ComboboxOption value="alice">Alice</ComboboxOption>
+                <ComboboxOption value="bob">Bob</ComboboxOption>
+                <ComboboxOption value="charlie">Charlie</ComboboxOption>
+              </ComboboxOptions>
+            </Combobox>
+        `);
+
+        // Open combobox
+        await click(getComboboxButton());
+
+        let options: ReturnType<typeof getComboboxOptions>;
+
+        // Bob should be active
+        options = getComboboxOptions();
+        expect(getComboboxInput()).toHaveValue("bob");
+        assertActiveComboboxOption(options[1]);
+
+        assertActiveElement(getComboboxInput());
+
+        // Delete a character
+        await press(Keys.Backspace);
+        expect(getComboboxInput()?.value).toBe("bo");
+        assertActiveComboboxOption(options[1]);
+
+        // Delete a character
+        await press(Keys.Backspace);
+        expect(getComboboxInput()?.value).toBe("b");
+        assertActiveComboboxOption(options[1]);
+
+        // Delete a character
+        await press(Keys.Backspace);
+        expect(getComboboxInput()?.value).toBe("");
+
+        // Verify that we don't have an active option anymore since we are in `nullable` mode
+        assertNotActiveComboboxOption(options[1]);
+        assertNoActiveComboboxOption();
+
+        // Verify that we saw the `null` change coming in
+        expect(handleChange).toHaveBeenCalledTimes(1);
+        expect(handleChange).toHaveBeenCalledWith(null);
+      })
+    );
+  });
+
+  describe("Input", () => {
+    describe("`Enter` key", () => {
+      it(
+        "should be possible to close the combobox with Enter and choose the active combobox option",
+        suppressConsoleLogs(async () => {
+          let handleChange = jest.fn();
+
+          render(svelte`
+          <script>
+            let value
+          </script>
+          <Combobox
+                value={value}
+                on:change={(event) => {
+                  value = event.detail
+                  handleChange(value);
+                }}
+              >
+                <ComboboxInput on:change={NOOP} />
+                <ComboboxButton>Trigger</ComboboxButton>
+                <ComboboxOptions>
+                  <ComboboxOption value="a">Option A</ComboboxOption>
+                  <ComboboxOption value="b">Option B</ComboboxOption>
+                  <ComboboxOption value="c">Option C</ComboboxOption>
+                </ComboboxOptions>
+              </Combobox>
+          `);
+
+          assertComboboxButton({
+            state: ComboboxState.InvisibleUnmounted,
+            attributes: { id: "headlessui-combobox-button-2" },
+          });
+          assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+          // Open combobox
+          await click(getComboboxButton());
+
+          // Verify it is visible
+          assertComboboxButton({ state: ComboboxState.Visible });
+
+          // Activate the first combobox option
+          let options = getComboboxOptions();
+          await mouseMove(options[0]);
+
+          // Choose option, and close combobox
+          await press(Keys.Enter);
+
+          // Verify it is closed
+          assertComboboxButton({ state: ComboboxState.InvisibleUnmounted });
+          assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+          // Verify we got the change event
+          expect(handleChange).toHaveBeenCalledTimes(1);
+          expect(handleChange).toHaveBeenCalledWith("a");
+
+          // Verify the button is focused again
+          assertActiveElement(getComboboxInput());
+
+          // Open combobox again
+          await click(getComboboxButton());
+
+          // Verify the active option is the previously selected one
+          assertActiveComboboxOption(getComboboxOptions()[0]);
+        })
+      );
+
+      it(
+        "should submit the form on `Enter`",
+        suppressConsoleLogs(async () => {
+          let submits = jest.fn();
+
+          render(svelte`
+          <script>
+            let value = "b"
+          </script>
+          <form
+                on:keyup={(event) => {
+                  // JSDom doesn't automatically submit the form but if we can
+                  // catch an "Enter" event, we can assume it was a submit.
+                  if (event.key === "Enter") event.currentTarget.submit();
+                }}
+                on:submit={(event) => {
+                  event.preventDefault();
+                  submits([...new FormData(event.currentTarget).entries()]);
+                }}
+              >
+                <Combobox value={value} on:change={(event) => value = event.detail} name="option">
+                  <ComboboxInput on:change={NOOP} />
+                  <ComboboxButton>Trigger</ComboboxButton>
+                  <ComboboxOptions>
+                    <ComboboxOption value="a">Option A</ComboboxOption>
+                    <ComboboxOption value="b">Option B</ComboboxOption>
+                    <ComboboxOption value="c">Option C</ComboboxOption>
+                  </ComboboxOptions>
+                </Combobox>
+
+                <button>Submit</button>
+              </form>
+          `);
+
+          // Focus the input field
+          await focus(getComboboxInput());
+          await nextFrame()
+          assertActiveElement(getComboboxInput());
+
+          // Press enter (which should submit the form)
+          await press(Keys.Enter);
+
+          // Verify the form was submitted
+          expect(submits).toHaveBeenCalledTimes(1);
+          expect(submits).toHaveBeenCalledWith([["option", "b"]]);
+        })
+      );
+    });
+
+    describe("`Tab` key", () => {
+      it(
+        "pressing Tab should select the active item and move to the next DOM node",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+          <script>
+            let value
+          </script>
+          <input id="before-combobox" />
+          <Combobox value={value} on:change={(event) => value = event.detail}>
+            <ComboboxInput on:change={NOOP} />
+            <ComboboxButton>Trigger</ComboboxButton>
+            <ComboboxOptions>
+              <ComboboxOption value="a">Option A</ComboboxOption>
+              <ComboboxOption value="b">Option B</ComboboxOption>
+              <ComboboxOption value="c">Option C</ComboboxOption>
+            </ComboboxOptions>
+          </Combobox>
+          <input id="after-combobox" />
+          `);
+
+          assertComboboxButton({
+            state: ComboboxState.InvisibleUnmounted,
+            attributes: { id: "headlessui-combobox-button-2" },
+          });
+          assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+          // Open combobox
+          await click(getComboboxButton());
+
+          // Select the 2nd option
+          await press(Keys.ArrowDown);
+
+          // Tab to the next DOM node
+          await press(Keys.Tab);
+
+          // Verify it is closed
+          assertComboboxButton({ state: ComboboxState.InvisibleUnmounted });
+          assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+          // That the selected value was the highlighted one
+          expect(getComboboxInput()?.value).toBe("b");
+
+          // And focus has moved to the next element
+          assertActiveElement(document.querySelector("#after-combobox"));
+        })
+      );
+
+      it(
+        "pressing Shift+Tab should select the active item and move to the previous DOM node",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+          <script>
+            let value
+          </script>
+          <input id="before-combobox" />
+          <Combobox value={value} on:change={(event) => value = event.detail}>
+            <ComboboxInput on:change={NOOP} />
+            <ComboboxButton>Trigger</ComboboxButton>
+            <ComboboxOptions>
+              <ComboboxOption value="a">Option A</ComboboxOption>
+              <ComboboxOption value="b">Option B</ComboboxOption>
+              <ComboboxOption value="c">Option C</ComboboxOption>
+            </ComboboxOptions>
+          </Combobox>
+          <input id="after-combobox" />
+          `);
+
+          assertComboboxButton({
+            state: ComboboxState.InvisibleUnmounted,
+            attributes: { id: "headlessui-combobox-button-2" },
+          });
+          assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+          // Open combobox
+          await click(getComboboxButton());
+
+          // Select the 2nd option
+          await press(Keys.ArrowDown);
+
+          // Tab to the next DOM node
+          await press(shift(Keys.Tab));
+
+          // Verify it is closed
+          assertComboboxButton({ state: ComboboxState.InvisibleUnmounted });
+          assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+          // That the selected value was the highlighted one
+          expect(getComboboxInput()?.value).toBe("b");
+
+          // And focus has moved to the next element
+          assertActiveElement(document.querySelector("#before-combobox"));
+        })
+      );
+    });
+
+    describe("`Escape` key", () => {
+      it(
+        "should be possible to close an open combobox with Escape",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value="test" on:change={console.log}>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                <ComboboxOption value="a">Option A</ComboboxOption>
+                <ComboboxOption value="b">Option B</ComboboxOption>
+                <ComboboxOption value="c">Option C</ComboboxOption>
+              </ComboboxOptions>
+            </Combobox>
+          `);
+
+          // Open combobox
+          await click(getComboboxButton());
+
+          // Verify it is visible
+          assertComboboxButton({ state: ComboboxState.Visible });
+          assertComboboxList({
+            state: ComboboxState.Visible,
+            attributes: { id: "headlessui-combobox-options-3" },
+          });
+          assertActiveElement(getComboboxInput());
+          assertComboboxButtonLinkedWithCombobox();
+
+          // Close combobox
+          await press(Keys.Escape);
+
+          // Verify it is closed
+          assertComboboxButton({ state: ComboboxState.InvisibleUnmounted });
+          assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+          // Verify the button is focused again
+          assertActiveElement(getComboboxInput());
+        })
+      );
+
+      it(
+        "should bubble escape when using `static` on ComboboxOptions",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value="test" on:change={console.log}>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions static>
+                <ComboboxOption value="a">Option A</ComboboxOption>
+                <ComboboxOption value="b">Option B</ComboboxOption>
+                <ComboboxOption value="c">Option C</ComboboxOption>
+              </ComboboxOptions>
+            </Combobox>
+          `);
+
+          let spy = jest.fn();
+
+          window.addEventListener(
+            "keydown",
+            (evt) => {
+              if (evt.key === "Escape") {
+                spy();
+              }
+            },
+            { capture: true }
+          );
+
+          window.addEventListener("keydown", (evt) => {
+            if (evt.key === "Escape") {
+              spy();
+            }
+          });
+
+          // Open combobox
+          await click(getComboboxButton());
+
+          // Verify the input is focused
+          assertActiveElement(getComboboxInput());
+
+          // Close combobox
+          await press(Keys.Escape);
+
+          // Verify the input is still focused
+          assertActiveElement(getComboboxInput());
+
+          // The external event handler should've been called twice
+          // Once in the capture phase and once in the bubble phase
+          expect(spy).toHaveBeenCalledTimes(2);
+        })
+      );
+
+      it(
+        "should bubble escape when not using ComboboxOptions at all",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value="test" on:change={console.log}>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+            </Combobox>
+          `);
+
+          let spy = jest.fn();
+
+          window.addEventListener(
+            "keydown",
+            (evt) => {
+              if (evt.key === "Escape") {
+                spy();
+              }
+            },
+            { capture: true }
+          );
+
+          window.addEventListener("keydown", (evt) => {
+            if (evt.key === "Escape") {
+              spy();
+            }
+          });
+
+          // Open combobox
+          await click(getComboboxButton());
+
+          // Verify the input is focused
+          assertActiveElement(getComboboxInput());
+
+          // Close combobox
+          await press(Keys.Escape);
+
+          // Verify the input is still focused
+          assertActiveElement(getComboboxInput());
+
+          // The external event handler should've been called twice
+          // Once in the capture phase and once in the bubble phase
+          expect(spy).toHaveBeenCalledTimes(2);
+        })
+      );
+
+      it(
+        "should sync the input field correctly and reset it when pressing Escape",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value="option-b" on:change={console.log}>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                <ComboboxOption value="option-a">Option A</ComboboxOption>
+                <ComboboxOption value="option-b">Option B</ComboboxOption>
+                <ComboboxOption value="option-c">Option C</ComboboxOption>
+              </ComboboxOptions>
+            </Combobox>
+          `);
+
+          // Open combobox
+          await click(getComboboxButton());
+
+          // Verify the input has the selected value
+          expect(getComboboxInput()?.value).toBe("option-b");
+
+          // Override the input by typing something
+          await type(word("test"), getComboboxInput());
+          expect(getComboboxInput()?.value).toBe("test");
+
+          // Close combobox
+          await press(Keys.Escape);
+
+          // Verify the input is reset correctly
+          expect(getComboboxInput()?.value).toBe("option-b");
+        })
+      );
+    });
+
+    describe("`ArrowDown` key", () => {
+      it(
+        "should be possible to open the combobox with ArrowDown",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value="test" on:change={console.log}>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                <ComboboxOption value="a">Option A</ComboboxOption>
+                <ComboboxOption value="b">Option B</ComboboxOption>
+                <ComboboxOption value="c">Option C</ComboboxOption>
+              </ComboboxOptions>
+            </Combobox>
+          `);
+
+          assertComboboxButton({
+            state: ComboboxState.InvisibleUnmounted,
+            attributes: { id: "headlessui-combobox-button-2" },
+          });
+          assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+          // Focus the input
+          await focus(getComboboxInput());
+
+          // Open combobox
+          await press(Keys.ArrowDown);
+
+          // Verify it is visible
+          assertComboboxButton({ state: ComboboxState.Visible });
+          assertComboboxList({
+            state: ComboboxState.Visible,
+            attributes: { id: "headlessui-combobox-options-3" },
+          });
+          assertActiveElement(getComboboxInput());
+          assertComboboxButtonLinkedWithCombobox();
+
+          // Verify we have combobox options
+          let options = getComboboxOptions();
+          expect(options).toHaveLength(3);
+          options.forEach((option) => assertComboboxOption(option));
+
+          // Verify that the first combobox option is active
+          assertActiveComboboxOption(options[0]);
+        })
+      );
+
+      it(
+        "should not be possible to open the combobox with ArrowDown when the button is disabled",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value={undefined} on:change={console.log} disabled>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                <ComboboxOption value="a">Option A</ComboboxOption>
+                <ComboboxOption value="b">Option B</ComboboxOption>
+                <ComboboxOption value="c">Option C</ComboboxOption>
+              </ComboboxOptions>
+            </Combobox>
+          `);
+
+          assertComboboxButton({
+            state: ComboboxState.InvisibleUnmounted,
+            attributes: { id: "headlessui-combobox-button-2" },
+          });
+          assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+          // Focus the input
+          await focus(getComboboxInput());
+
+          // Try to open the combobox
+          await press(Keys.ArrowDown);
+
+          // Verify it is still closed
+          assertComboboxButton({
+            state: ComboboxState.InvisibleUnmounted,
+            attributes: { id: "headlessui-combobox-button-2" },
+          });
+          assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+        })
+      );
+
+      it(
+        "should be possible to open the combobox with ArrowDown, and focus the selected option",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value="b" on:change={console.log}>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                <ComboboxOption value="a">Option A</ComboboxOption>
+                <ComboboxOption value="b">Option B</ComboboxOption>
+                <ComboboxOption value="c">Option C</ComboboxOption>
+              </ComboboxOptions>
+            </Combobox>
+          `);
+
+          assertComboboxButton({
+            state: ComboboxState.InvisibleUnmounted,
+            attributes: { id: "headlessui-combobox-button-2" },
+          });
+          assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+          // Focus the input
+          await focus(getComboboxInput());
+
+          // Open combobox
+          await press(Keys.ArrowDown);
+
+          // Verify it is visible
+          assertComboboxButton({ state: ComboboxState.Visible });
+          assertComboboxList({
+            state: ComboboxState.Visible,
+            attributes: { id: "headlessui-combobox-options-3" },
+          });
+          assertActiveElement(getComboboxInput());
+          assertComboboxButtonLinkedWithCombobox();
+
+          // Verify we have combobox options
+          let options = getComboboxOptions();
+          expect(options).toHaveLength(3);
+          options.forEach((option, i) =>
+            assertComboboxOption(option, { selected: i === 1 })
+          );
+
+          // Verify that the second combobox option is active (because it is already selected)
+          assertActiveComboboxOption(options[1]);
+        })
+      );
+
+      it(
+        "should have no active combobox option when there are no combobox options at all",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value="test" on:change={console.log}>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions />
+            </Combobox>
+          `);
+
+          assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+          // Focus the input
+          await focus(getComboboxInput());
+
+          // Open combobox
+          await press(Keys.ArrowDown);
+          assertComboboxList({ state: ComboboxState.Visible });
+          assertActiveElement(getComboboxInput());
+
+          assertNoActiveComboboxOption();
+        })
+      );
+
+      it(
+        "should be possible to use ArrowDown to navigate the combobox options",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value="test" on:change={console.log}>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                <ComboboxOption value="a">Option A</ComboboxOption>
+                <ComboboxOption value="b">Option B</ComboboxOption>
+                <ComboboxOption value="c">Option C</ComboboxOption>
+              </ComboboxOptions>
+            </Combobox>
+          `);
+
+          assertComboboxButton({
+            state: ComboboxState.InvisibleUnmounted,
+            attributes: { id: "headlessui-combobox-button-2" },
+          });
+          assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+          // Open combobox
+          await click(getComboboxButton());
+
+          // Verify we have combobox options
+          let options = getComboboxOptions();
+          expect(options).toHaveLength(3);
+          options.forEach((option) => assertComboboxOption(option));
+          assertActiveComboboxOption(options[0]);
+
+          // We should be able to go down once
+          await press(Keys.ArrowDown);
+          assertActiveComboboxOption(options[1]);
+
+          // We should be able to go down again
+          await press(Keys.ArrowDown);
+          assertActiveComboboxOption(options[2]);
+
+          // We should NOT be able to go down again (because last option).
+          // Current implementation won't go around.
+          await press(Keys.ArrowDown);
+          assertActiveComboboxOption(options[2]);
+        })
+      );
+
+      it(
+        "should be possible to use ArrowDown to navigate the combobox options and skip the first disabled one",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value="test" on:change={console.log}>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                <ComboboxOption disabled value="a">
+                  Option A
+                </ComboboxOption>
+                <ComboboxOption value="b">Option B</ComboboxOption>
+                <ComboboxOption value="c">Option C</ComboboxOption>
+              </ComboboxOptions>
+            </Combobox>
+          `);
+
+          assertComboboxButton({
+            state: ComboboxState.InvisibleUnmounted,
+            attributes: { id: "headlessui-combobox-button-2" },
+          });
+          assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+          // Open combobox
+          await click(getComboboxButton());
+
+          // Verify we have combobox options
+          let options = getComboboxOptions();
+          expect(options).toHaveLength(3);
+          options.forEach((option) => assertComboboxOption(option));
+          assertActiveComboboxOption(options[1]);
+
+          // We should be able to go down once
+          await press(Keys.ArrowDown);
+          assertActiveComboboxOption(options[2]);
+        })
+      );
+
+      it(
+        "should be possible to use ArrowDown to navigate the combobox options and jump to the first non-disabled one",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value="test" on:change={console.log}>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                <ComboboxOption disabled value="a">
+                  Option A
+                </ComboboxOption>
+                <ComboboxOption disabled value="b">
+                  Option B
+                </ComboboxOption>
+                <ComboboxOption value="c">Option C</ComboboxOption>
+              </ComboboxOptions>
+            </Combobox>
+          `);
+
+          assertComboboxButton({
+            state: ComboboxState.InvisibleUnmounted,
+            attributes: { id: "headlessui-combobox-button-2" },
+          });
+          assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+          // Open combobox
+          await click(getComboboxButton());
+
+          // Verify we have combobox options
+          let options = getComboboxOptions();
+          expect(options).toHaveLength(3);
+          options.forEach((option) => assertComboboxOption(option));
+          assertActiveComboboxOption(options[2]);
+
+          // Open combobox
+          await press(Keys.ArrowDown);
+          assertActiveComboboxOption(options[2]);
+        })
+      );
+
+      it(
+        "should be possible to go to the next item if no value is set",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value={null} on:change={console.log}>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                <ComboboxOption value="a">Option A</ComboboxOption>
+                <ComboboxOption value="b">Option B</ComboboxOption>
+                <ComboboxOption value="c">Option C</ComboboxOption>
+              </ComboboxOptions>
+            </Combobox>
+          `);
+
+          assertComboboxButton({
+            state: ComboboxState.InvisibleUnmounted,
+            attributes: { id: "headlessui-combobox-button-2" },
+          });
+          assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+          // Open combobox
+          await click(getComboboxButton());
+
+          let options = getComboboxOptions();
+
+          // Verify that we are on the first option
+          assertActiveComboboxOption(options[0]);
+
+          // Go down once
+          await press(Keys.ArrowDown);
+
+          // We should be on the next item
+          assertActiveComboboxOption(options[1]);
+        })
+      );
+    });
+
+    describe("`ArrowUp` key", () => {
+      it(
+        "should be possible to open the combobox with ArrowUp and the last option should be active",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value={undefined} on:change={console.log}>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                <ComboboxOption value="a">Option A</ComboboxOption>
+                <ComboboxOption value="b">Option B</ComboboxOption>
+                <ComboboxOption value="c">Option C</ComboboxOption>
+              </ComboboxOptions>
+            </Combobox>
+          `);
+
+          assertComboboxButton({
+            state: ComboboxState.InvisibleUnmounted,
+            attributes: { id: "headlessui-combobox-button-2" },
+          });
+          assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+          // Focus the input
+          await focus(getComboboxInput());
+
+          // Open combobox
+          await press(Keys.ArrowUp);
+
+          // Verify it is visible
+          assertComboboxButton({ state: ComboboxState.Visible });
+          assertComboboxList({
+            state: ComboboxState.Visible,
+            attributes: { id: "headlessui-combobox-options-3" },
+          });
+          assertActiveElement(getComboboxInput());
+          assertComboboxButtonLinkedWithCombobox();
+
+          // Verify we have combobox options
+          let options = getComboboxOptions();
+          expect(options).toHaveLength(3);
+          options.forEach((option) => assertComboboxOption(option));
+
+          // ! ALERT: The LAST option should now be active
+          assertActiveComboboxOption(options[2]);
+        })
+      );
+
+      it(
+        "should not be possible to open the combobox with ArrowUp and the last option should be active when the button is disabled",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value={undefined} on:change={console.log} disabled>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                <ComboboxOption value="a">Option A</ComboboxOption>
+                <ComboboxOption value="b">Option B</ComboboxOption>
+                <ComboboxOption value="c">Option C</ComboboxOption>
+              </ComboboxOptions>
+            </Combobox>
+          `);
+
+          assertComboboxButton({
+            state: ComboboxState.InvisibleUnmounted,
+            attributes: { id: "headlessui-combobox-button-2" },
+          });
+          assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+          // Focus the input
+          await focus(getComboboxInput());
+
+          // Try to open the combobox
+          await press(Keys.ArrowUp);
+
+          // Verify it is still closed
+          assertComboboxButton({
+            state: ComboboxState.InvisibleUnmounted,
+            attributes: { id: "headlessui-combobox-button-2" },
+          });
+          assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+        })
+      );
+
+      it(
+        "should be possible to open the combobox with ArrowUp, and focus the selected option",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value="b" on:change={console.log}>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                <ComboboxOption value="a">Option A</ComboboxOption>
+                <ComboboxOption value="b">Option B</ComboboxOption>
+                <ComboboxOption value="c">Option C</ComboboxOption>
+              </ComboboxOptions>
+            </Combobox>
+          `);
+
+          assertComboboxButton({
+            state: ComboboxState.InvisibleUnmounted,
+            attributes: { id: "headlessui-combobox-button-2" },
+          });
+          assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+          // Focus the input
+          await focus(getComboboxInput());
+
+          // Open combobox
+          await press(Keys.ArrowUp);
+
+          // Verify it is visible
+          assertComboboxButton({ state: ComboboxState.Visible });
+          assertComboboxList({
+            state: ComboboxState.Visible,
+            attributes: { id: "headlessui-combobox-options-3" },
+          });
+          assertActiveElement(getComboboxInput());
+          assertComboboxButtonLinkedWithCombobox();
+
+          // Verify we have combobox options
+          let options = getComboboxOptions();
+          expect(options).toHaveLength(3);
+          options.forEach((option, i) =>
+            assertComboboxOption(option, { selected: i === 1 })
+          );
+
+          // Verify that the second combobox option is active (because it is already selected)
+          assertActiveComboboxOption(options[1]);
+        })
+      );
+
+      it(
+        "should have no active combobox option when there are no combobox options at all",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value="test" on:change={console.log}>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions />
+            </Combobox>
+          `);
+
+          assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+          // Focus the input
+          await focus(getComboboxInput());
+
+          // Open combobox
+          await press(Keys.ArrowUp);
+          assertComboboxList({ state: ComboboxState.Visible });
+          assertActiveElement(getComboboxInput());
+
+          assertNoActiveComboboxOption();
+        })
+      );
+
+      it(
+        "should be possible to use ArrowUp to navigate the combobox options and jump to the first non-disabled one",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value={undefined} on:change={console.log}>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                <ComboboxOption value="a">Option A</ComboboxOption>
+                <ComboboxOption disabled value="b">
+                  Option B
+                </ComboboxOption>
+                <ComboboxOption disabled value="c">
+                  Option C
+                </ComboboxOption>
+              </ComboboxOptions>
+            </Combobox>
+          `);
+
+          assertComboboxButton({
+            state: ComboboxState.InvisibleUnmounted,
+            attributes: { id: "headlessui-combobox-button-2" },
+          });
+          assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+          // Focus the input
+          await focus(getComboboxInput());
+
+          // Open combobox
+          await press(Keys.ArrowUp);
+
+          // Verify we have combobox options
+          let options = getComboboxOptions();
+          expect(options).toHaveLength(3);
+          options.forEach((option) => assertComboboxOption(option));
+          assertActiveComboboxOption(options[0]);
+        })
+      );
+
+      it(
+        "should not be possible to navigate up or down if there is only a single non-disabled option",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value={undefined} on:change={console.log}>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                <ComboboxOption disabled value="a">
+                  Option A
+                </ComboboxOption>
+                <ComboboxOption disabled value="b">
+                  Option B
+                </ComboboxOption>
+                <ComboboxOption value="c">Option C</ComboboxOption>
+              </ComboboxOptions>
+            </Combobox>
+          `);
+
+          assertComboboxButton({
+            state: ComboboxState.InvisibleUnmounted,
+            attributes: { id: "headlessui-combobox-button-2" },
+          });
+          assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+          // Open combobox
+          await click(getComboboxButton());
+
+          // Verify we have combobox options
+          let options = getComboboxOptions();
+          expect(options).toHaveLength(3);
+          options.forEach((option) => assertComboboxOption(option));
+          assertActiveComboboxOption(options[2]);
+
+          // Going up or down should select the single available option
+          await press(Keys.ArrowUp);
+
+          // We should not be able to go up (because those are disabled)
+          await press(Keys.ArrowUp);
+          assertActiveComboboxOption(options[2]);
+
+          // We should not be able to go down (because this is the last option)
+          await press(Keys.ArrowDown);
+          assertActiveComboboxOption(options[2]);
+        })
+      );
+
+      it(
+        "should be possible to use ArrowUp to navigate the combobox options",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value={undefined} on:change={console.log}>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                <ComboboxOption value="a">Option A</ComboboxOption>
+                <ComboboxOption value="b">Option B</ComboboxOption>
+                <ComboboxOption value="c">Option C</ComboboxOption>
+              </ComboboxOptions>
+            </Combobox>
+          `);
+
+          assertComboboxButton({
+            state: ComboboxState.InvisibleUnmounted,
+            attributes: { id: "headlessui-combobox-button-2" },
+          });
+          assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+          // Focus the input
+          await focus(getComboboxInput());
+
+          // Open combobox
+          await press(Keys.ArrowUp);
+
+          // Verify it is visible
+          assertComboboxButton({ state: ComboboxState.Visible });
+          assertComboboxList({
+            state: ComboboxState.Visible,
+            attributes: { id: "headlessui-combobox-options-3" },
+          });
+          assertActiveElement(getComboboxInput());
+          assertComboboxButtonLinkedWithCombobox();
+
+          // Verify we have combobox options
+          let options = getComboboxOptions();
+          expect(options).toHaveLength(3);
+          options.forEach((option) => assertComboboxOption(option));
+          assertActiveComboboxOption(options[2]);
+
+          // We should be able to go down once
+          await press(Keys.ArrowUp);
+          assertActiveComboboxOption(options[1]);
+
+          // We should be able to go down again
+          await press(Keys.ArrowUp);
+          assertActiveComboboxOption(options[0]);
+
+          // We should NOT be able to go up again (because first option). Current implementation won't go around.
+          await press(Keys.ArrowUp);
+          assertActiveComboboxOption(options[0]);
+        })
+      );
+    });
+
+    describe("`End` key", () => {
+      it(
+        "should be possible to use the End key to go to the last combobox option",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value={undefined} on:change={console.log}>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                <ComboboxOption value="a">Option A</ComboboxOption>
+                <ComboboxOption value="b">Option B</ComboboxOption>
+                <ComboboxOption value="c">Option C</ComboboxOption>
+              </ComboboxOptions>
+            </Combobox>
+          `);
+
+          // Open combobox
+          await click(getComboboxButton());
+
+          let options = getComboboxOptions();
+
+          // We should be on the first non-disabled option
+          assertActiveComboboxOption(options[0]);
+
+          // We should be able to go to the last option
+          await press(Keys.End);
+          assertActiveComboboxOption(options[2]);
+        })
+      );
+
+      it(
+        "should be possible to use the End key to go to the last non disabled combobox option",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value="test" on:change={console.log}>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                <ComboboxOption value="a">Option A</ComboboxOption>
+                <ComboboxOption value="b">Option B</ComboboxOption>
+                <ComboboxOption disabled value="c">
+                  Option C
+                </ComboboxOption>
+                <ComboboxOption disabled value="d">
+                  Option D
+                </ComboboxOption>
+              </ComboboxOptions>
+            </Combobox>
+          `);
+
+          // Open combobox
+          await click(getComboboxButton());
+
+          let options = getComboboxOptions();
+
+          // We should be on the first non-disabled option
+          assertActiveComboboxOption(options[0]);
+
+          // We should be able to go to the last non-disabled option
+          await press(Keys.End);
+          assertActiveComboboxOption(options[1]);
+        })
+      );
+
+      it(
+        "should be possible to use the End key to go to the first combobox option if that is the only non-disabled combobox option",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value="test" on:change={console.log}>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                <ComboboxOption value="a">Option A</ComboboxOption>
+                <ComboboxOption disabled value="b">
+                  Option B
+                </ComboboxOption>
+                <ComboboxOption disabled value="c">
+                  Option C
+                </ComboboxOption>
+                <ComboboxOption disabled value="d">
+                  Option D
+                </ComboboxOption>
+              </ComboboxOptions>
+            </Combobox>
+          `);
+
+          // Open combobox
+          await click(getComboboxButton());
+
+          let options = getComboboxOptions();
+
+          // We should be on the first non-disabled option
+          assertActiveComboboxOption(options[0]);
+
+          // We should not be able to go to the end (no-op)
+          await press(Keys.End);
+
+          assertActiveComboboxOption(options[0]);
+        })
+      );
+
+      it(
+        "should have no active combobox option upon End key press, when there are no non-disabled combobox options",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value="test" on:change={console.log}>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                <ComboboxOption disabled value="a">
+                  Option A
+                </ComboboxOption>
+                <ComboboxOption disabled value="b">
+                  Option B
+                </ComboboxOption>
+                <ComboboxOption disabled value="c">
+                  Option C
+                </ComboboxOption>
+                <ComboboxOption disabled value="d">
+                  Option D
+                </ComboboxOption>
+              </ComboboxOptions>
+            </Combobox>
+          `);
+
+          // Open combobox
+          await click(getComboboxButton());
+
+          // We opened via click, we don't have an active option
+          assertNoActiveComboboxOption();
+
+          // We should not be able to go to the end
+          await press(Keys.End);
+
+          assertNoActiveComboboxOption();
+        })
+      );
+    });
+
+    describe("`PageDown` key", () => {
+      it(
+        "should be possible to use the PageDown key to go to the last combobox option",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value="test" on:change={console.log}>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                <ComboboxOption value="a">Option A</ComboboxOption>
+                <ComboboxOption value="b">Option B</ComboboxOption>
+                <ComboboxOption value="c">Option C</ComboboxOption>
+              </ComboboxOptions>
+            </Combobox>
+          `);
+
+          // Open combobox
+          await click(getComboboxButton());
+
+          let options = getComboboxOptions();
+
+          // We should be on the first option
+          assertActiveComboboxOption(options[0]);
+
+          // We should be able to go to the last option
+          await press(Keys.PageDown);
+          assertActiveComboboxOption(options[2]);
+        })
+      );
+
+      it(
+        "should be possible to use the PageDown key to go to the last non disabled combobox option",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value="test" on:change={console.log}>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                <ComboboxOption value="a">Option A</ComboboxOption>
+                <ComboboxOption value="b">Option B</ComboboxOption>
+                <ComboboxOption disabled value="c">
+                  Option C
+                </ComboboxOption>
+                <ComboboxOption disabled value="d">
+                  Option D
+                </ComboboxOption>
+              </ComboboxOptions>
+            </Combobox>
+          `);
+
+          // Open combobox
+          await click(getComboboxButton());
+
+          // Open combobox
+          await press(Keys.Space);
+
+          let options = getComboboxOptions();
+
+          // We should be on the first non-disabled option
+          assertActiveComboboxOption(options[0]);
+
+          // We should be able to go to the last non-disabled option
+          await press(Keys.PageDown);
+          assertActiveComboboxOption(options[1]);
+        })
+      );
+
+      it(
+        "should be possible to use the PageDown key to go to the first combobox option if that is the only non-disabled combobox option",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value="test" on:change={console.log}>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                <ComboboxOption value="a">Option A</ComboboxOption>
+                <ComboboxOption disabled value="b">
+                  Option B
+                </ComboboxOption>
+                <ComboboxOption disabled value="c">
+                  Option C
+                </ComboboxOption>
+                <ComboboxOption disabled value="d">
+                  Option D
+                </ComboboxOption>
+              </ComboboxOptions>
+            </Combobox>
+          `);
+
+          // Open combobox
+          await click(getComboboxButton());
+
+          let options = getComboboxOptions();
+
+          // We should be on the first non-disabled option
+          assertActiveComboboxOption(options[0]);
+
+          // We should not be able to go to the end
+          await press(Keys.PageDown);
+
+          assertActiveComboboxOption(options[0]);
+        })
+      );
+
+      it(
+        "should have no active combobox option upon PageDown key press, when there are no non-disabled combobox options",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value="test" on:change={console.log}>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                <ComboboxOption disabled value="a">
+                  Option A
+                </ComboboxOption>
+                <ComboboxOption disabled value="b">
+                  Option B
+                </ComboboxOption>
+                <ComboboxOption disabled value="c">
+                  Option C
+                </ComboboxOption>
+                <ComboboxOption disabled value="d">
+                  Option D
+                </ComboboxOption>
+              </ComboboxOptions>
+            </Combobox>
+          `);
+
+          // Open combobox
+          await click(getComboboxButton());
+
+          // We opened via click, we don't have an active option
+          assertNoActiveComboboxOption();
+
+          // We should not be able to go to the end
+          await press(Keys.PageDown);
+
+          assertNoActiveComboboxOption();
+        })
+      );
+    });
+
+    describe("`Home` key", () => {
+      it(
+        "should be possible to use the Home key to go to the first combobox option",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value={undefined} on:change={console.log}>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                <ComboboxOption value="a">Option A</ComboboxOption>
+                <ComboboxOption value="b">Option B</ComboboxOption>
+                <ComboboxOption value="c">Option C</ComboboxOption>
+              </ComboboxOptions>
+            </Combobox>
+          `);
+
+          // Focus the input
+          await focus(getComboboxInput());
+
+          // Open combobox
+          await press(Keys.ArrowUp);
+
+          let options = getComboboxOptions();
+
+          // We should be on the last option
+          assertActiveComboboxOption(options[2]);
+
+          // We should be able to go to the first option
+          await press(Keys.Home);
+          assertActiveComboboxOption(options[0]);
+        })
+      );
+
+      it(
+        "should be possible to use the Home key to go to the first non disabled combobox option",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value={undefined} on:change={console.log}>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                <ComboboxOption disabled value="a">
+                  Option A
+                </ComboboxOption>
+                <ComboboxOption disabled value="b">
+                  Option B
+                </ComboboxOption>
+                <ComboboxOption value="c">Option C</ComboboxOption>
+                <ComboboxOption value="d">Option D</ComboboxOption>
+              </ComboboxOptions>
+            </Combobox>
+          `);
+
+          // Open combobox
+          await click(getComboboxButton());
+
+          let options = getComboboxOptions();
+
+          // We should be on the first non-disabled option
+          assertActiveComboboxOption(options[2]);
+
+          // We should not be able to go to the end
+          await press(Keys.Home);
+
+          // We should be on the first non-disabled option
+          assertActiveComboboxOption(options[2]);
+        })
+      );
+
+      it(
+        "should be possible to use the Home key to go to the last combobox option if that is the only non-disabled combobox option",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value="test" on:change={console.log}>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                <ComboboxOption disabled value="a">
+                  Option A
+                </ComboboxOption>
+                <ComboboxOption disabled value="b">
+                  Option B
+                </ComboboxOption>
+                <ComboboxOption disabled value="c">
+                  Option C
+                </ComboboxOption>
+                <ComboboxOption value="d">Option D</ComboboxOption>
+              </ComboboxOptions>
+            </Combobox>
+          `);
+
+          // Open combobox
+          await click(getComboboxButton());
+
+          let options = getComboboxOptions();
+
+          // We should be on the last option
+          assertActiveComboboxOption(options[3]);
+
+          // We should not be able to go to the end
+          await press(Keys.Home);
+
+          assertActiveComboboxOption(options[3]);
+        })
+      );
+
+      it(
+        "should have no active combobox option upon Home key press, when there are no non-disabled combobox options",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value="test" on:change={console.log}>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                <ComboboxOption disabled value="a">
+                  Option A
+                </ComboboxOption>
+                <ComboboxOption disabled value="b">
+                  Option B
+                </ComboboxOption>
+                <ComboboxOption disabled value="c">
+                  Option C
+                </ComboboxOption>
+                <ComboboxOption disabled value="d">
+                  Option D
+                </ComboboxOption>
+              </ComboboxOptions>
+            </Combobox>
+          `);
+
+          // Open combobox
+          await click(getComboboxButton());
+
+          // We opened via click, we don't have an active option
+          assertNoActiveComboboxOption();
+
+          // We should not be able to go to the end
+          await press(Keys.Home);
+
+          assertNoActiveComboboxOption();
+        })
+      );
+    });
+
+    describe("`PageUp` key", () => {
+      it(
+        "should be possible to use the PageUp key to go to the first combobox option",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value={undefined} on:change={console.log}>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                <ComboboxOption value="a">Option A</ComboboxOption>
+                <ComboboxOption value="b">Option B</ComboboxOption>
+                <ComboboxOption value="c">Option C</ComboboxOption>
+              </ComboboxOptions>
+            </Combobox>
+          `);
+
+          // Focus the input
+          await focus(getComboboxInput());
+
+          // Open combobox
+          await press(Keys.ArrowUp);
+
+          let options = getComboboxOptions();
+
+          // We should be on the last option
+          assertActiveComboboxOption(options[2]);
+
+          // We should be able to go to the first option
+          await press(Keys.PageUp);
+          assertActiveComboboxOption(options[0]);
+        })
+      );
+
+      it(
+        "should be possible to use the PageUp key to go to the first non disabled combobox option",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value="test" on:change={console.log}>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                <ComboboxOption disabled value="a">
+                  Option A
+                </ComboboxOption>
+                <ComboboxOption disabled value="b">
+                  Option B
+                </ComboboxOption>
+                <ComboboxOption value="c">Option C</ComboboxOption>
+                <ComboboxOption value="d">Option D</ComboboxOption>
+              </ComboboxOptions>
+            </Combobox>
+          `);
+
+          // Open combobox
+          await click(getComboboxButton());
+
+          let options = getComboboxOptions();
+
+          // We opened via click, we default to the first non-disabled option
+          assertActiveComboboxOption(options[2]);
+
+          // We should not be able to go to the end (no-op — already there)
+          await press(Keys.PageUp);
+
+          assertActiveComboboxOption(options[2]);
+        })
+      );
+
+      it(
+        "should be possible to use the PageUp key to go to the last combobox option if that is the only non-disabled combobox option",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value="test" on:change={console.log}>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                <ComboboxOption disabled value="a">
+                  Option A
+                </ComboboxOption>
+                <ComboboxOption disabled value="b">
+                  Option B
+                </ComboboxOption>
+                <ComboboxOption disabled value="c">
+                  Option C
+                </ComboboxOption>
+                <ComboboxOption value="d">Option D</ComboboxOption>
+              </ComboboxOptions>
+            </Combobox>
+          `);
+
+          // Open combobox
+          await click(getComboboxButton());
+
+          let options = getComboboxOptions();
+
+          // We opened via click, we default to the first non-disabled option
+          assertActiveComboboxOption(options[3]);
+
+          // We should not be able to go to the end (no-op — already there)
+          await press(Keys.PageUp);
+
+          assertActiveComboboxOption(options[3]);
+        })
+      );
+
+      it(
+        "should have no active combobox option upon PageUp key press, when there are no non-disabled combobox options",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <Combobox value="test" on:change={console.log}>
+              <ComboboxInput on:change={NOOP} />
+              <ComboboxButton>Trigger</ComboboxButton>
+              <ComboboxOptions>
+                <ComboboxOption disabled value="a">
+                  Option A
+                </ComboboxOption>
+                <ComboboxOption disabled value="b">
+                  Option B
+                </ComboboxOption>
+                <ComboboxOption disabled value="c">
+                  Option C
+                </ComboboxOption>
+                <ComboboxOption disabled value="d">
+                  Option D
+                </ComboboxOption>
+              </ComboboxOptions>
+            </Combobox>
+          `);
+
+          // Open combobox
+          await click(getComboboxButton());
+
+          // We opened via click, we don't have an active option
+          assertNoActiveComboboxOption();
+
+          // We should not be able to go to the end
+          await press(Keys.PageUp);
+
+          assertNoActiveComboboxOption();
+        })
+      );
+    });
+
+    describe("`Any` key aka search", () => {
+      it(
+        "should be possible to type a full word that has a perfect match",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+            <script>
+            let people = [
+              { value: "alice", name: "alice", disabled: false },
+              { value: "bob", name: "bob", disabled: false },
+              { value: "charlie", name: "charlie", disabled: false },
+            ]
+            let value
+            let query = ""
+
+            let filteredPeople =
+            query === ""
+              ? people
+              : people.filter((person) =>
+                  person.name.toLowerCase().includes(query.toLowerCase())
+                );
+
+            </script>
+            <Combobox value={value} on:change={(event) => value = event.detail}>
+            <ComboboxInput
+              on:change={(event) => query = (event.target.value)}
+            />
+            <ComboboxButton>Trigger</ComboboxButton>
+            <ComboboxOptions>
+              {#each filteredPeople as person}              
+                <ComboboxOption                  
+                  value={person.value}
+                  disabled={person.disabled}
+                >
+                  {person.name}
+                </ComboboxOption>
+                {/each}
+            </ComboboxOptions>
+          </Combobox>
+          `);
+
+          // Open combobox
+          await click(getComboboxButton());
+
+          // Verify we moved focus to the input field
+          assertActiveElement(getComboboxInput());
+          let options: ReturnType<typeof getComboboxOptions>;
+
+          // We should be able to go to the second option
+          await type(word("bob"));
+          await press(Keys.Home);
+
+          options = getComboboxOptions();
+          expect(options).toHaveLength(1);
+          expect(options[0]).toHaveTextContent("bob");
+          assertActiveComboboxOption(options[0]);
+
+          // We should be able to go to the first option
+          await type(word("alice"));
+          await press(Keys.Home);
+
+          options = getComboboxOptions();
+          expect(options).toHaveLength(1);
+          expect(options[0]).toHaveTextContent("alice");
+          assertActiveComboboxOption(options[0]);
+
+          // We should be able to go to the last option
+          await type(word("charlie"));
+          await press(Keys.Home);
+
+          options = getComboboxOptions();
+          expect(options).toHaveLength(1);
+          expect(options[0]).toHaveTextContent("charlie");
+          assertActiveComboboxOption(options[0]);
+        })
+      );
+
+      it(
+        "should be possible to type a partial of a word",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+          <script>
+            let people = [
+              { value: "alice", name: "alice", disabled: false },
+              { value: "bob", name: "bob", disabled: false },
+              { value: "charlie", name: "charlie", disabled: false },
+            ]
+            let value
+            let query = ""
+
+            let filteredPeople =
+            query === ""
+              ? people
+              : people.filter((person) =>
+                  person.name.toLowerCase().includes(query.toLowerCase())
+                );
+
+          </script>
+          <Combobox value={value} on:change={(event) => value = event.detail}>
+            <ComboboxInput
+              on:change={(event) => query = (event.target.value)}
+            />
+            <ComboboxButton>Trigger</ComboboxButton>
+            <ComboboxOptions>
+            {#each filteredPeople as person}
+                <ComboboxOption                  
+                  value={person.value}
+                  disabled={person.disabled}
+                >
+                  {person.name}
+                </ComboboxOption>
+              {/each}
+            </ComboboxOptions>
+          </Combobox>
+          `);
+
+          // Open combobox
+          await click(getComboboxButton());
+
+          let options: ReturnType<typeof getComboboxOptions>;
+
+          // We should be able to go to the second option
+          await type(word("bo"));
+          await press(Keys.Home);
+          options = getComboboxOptions();
+          expect(options).toHaveLength(1);
+          expect(options[0]).toHaveTextContent("bob");
+          assertActiveComboboxOption(options[0]);
+
+          // We should be able to go to the first option
+          await type(word("ali"));
+          await press(Keys.Home);
+          options = getComboboxOptions();
+          expect(options).toHaveLength(1);
+          expect(options[0]).toHaveTextContent("alice");
+          assertActiveComboboxOption(options[0]);
+
+          // We should be able to go to the last option
+          await type(word("char"));
+          await press(Keys.Home);
+          options = getComboboxOptions();
+          expect(options).toHaveLength(1);
+          expect(options[0]).toHaveTextContent("charlie");
+          assertActiveComboboxOption(options[0]);
+        })
+      );
+
+      it(
+        "should be possible to type words with spaces",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+          <script>
+            let people = [
+              { value: "alice", name: "alice jones", disabled: false },
+              { value: "bob", name: "bob the builder", disabled: false },
+              { value: "charlie", name: "charlie bit me", disabled: false },
+            ]
+            let value
+            let query = ""
+
+            let filteredPeople =
+            query === ""
+              ? people
+              : people.filter((person) =>
+                  person.name.toLowerCase().includes(query.toLowerCase())
+                );
+
+          </script>
+          <Combobox value={value} on:change={(event) => value = event.detail}>
+            <ComboboxInput
+              on:change={(event) => query = event.detail}
+            />
+            <ComboboxButton>Trigger</ComboboxButton>
+            <ComboboxOptions>
+            {#each filteredPeople as person}
+                <ComboboxOption                  
+                  value={person.value}
+                  disabled={person.disabled}
+                >
+                  {person.name}
+                </ComboboxOption>
+              {/each}
+            </ComboboxOptions>
+          </Combobox>            
+          `);
+
+          // Open combobox
+          await click(getComboboxButton());
+
+          let options: ReturnType<typeof getComboboxOptions>;
+
+          // We should be able to go to the second option
+          await type(word("bob t"));
+          await press(Keys.Home);
+          options = getComboboxOptions();
+          expect(options).toHaveLength(1);
+          expect(options[0]).toHaveTextContent("bob the builder");
+          assertActiveComboboxOption(options[0]);
+
+          // We should be able to go to the first option
+          await type(word("alice j"));
+          await press(Keys.Home);
+          options = getComboboxOptions();
+          expect(options).toHaveLength(1);
+          expect(options[0]).toHaveTextContent("alice jones");
+          assertActiveComboboxOption(options[0]);
+
+          // We should be able to go to the last option
+          await type(word("charlie b"));
+          await press(Keys.Home);
+          options = getComboboxOptions();
+          expect(options).toHaveLength(1);
+          expect(options[0]).toHaveTextContent("charlie bit me");
+          assertActiveComboboxOption(options[0]);
+        })
+      );
+
+      it(
+        "should not be possible to search and activate a disabled option",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+          <script>
+          let people = [
+            { value: "alice", name: "alice", disabled: false },
+            { value: "bob", name: "bob", disabled: true },
+            { value: "charlie", name: "charlie", disabled: false },
+          ]
+          let value
+          let query = ""
+
+          let filteredPeople =
+          query === ""
+            ? people
+            : people.filter((person) =>
+                person.name.toLowerCase().includes(query.toLowerCase())
+              );
+
+        </script>
+        <Combobox value={value} on:change={(event) => value = event.detail}>
+          <ComboboxInput
+            on:change={(event) => query = event.detail}
+          />
+          <ComboboxButton>Trigger</ComboboxButton>
+          <ComboboxOptions>
+          {#each filteredPeople as person}
+              <ComboboxOption                
+                value={person.value}
+                disabled={person.disabled}
+              >
+                {person.name}
+              </ComboboxOption>
+            {/each}
+          </ComboboxOptions>
+        </Combobox>            
+          `);
+
+          // Open combobox
+          await click(getComboboxButton());
+
+          // We should not be able to go to the disabled option
+          await type(word("bo"));
+          await press(Keys.Home);
+
+          assertNoActiveComboboxOption();
+          assertNoSelectedComboboxOption();
+        })
+      );
+
+      it(
+        "should maintain activeIndex and activeOption when filtering",
+        suppressConsoleLogs(async () => {
+          render(svelte`
+          <script>
+          let people = [
+            { value: "a", name: "person a", disabled: false },
+            { value: "b", name: "person b", disabled: false },
+            { value: "c", name: "person c", disabled: false },
+          ]
+          let value
+          let query = ""
+
+          let filteredPeople =
+          query === ""
+            ? people
+            : people.filter((person) =>
+                person.name.toLowerCase().includes(query.toLowerCase())
+              );
+
+        </script>
+        <Combobox value={value} on:change={(event) => value = event.detail}>
+          <ComboboxInput
+            on:change={(event) => query = event.detail}
+          />
+          <ComboboxButton>Trigger</ComboboxButton>
+          <ComboboxOptions>
+          {#each filteredPeople as person}
+              <ComboboxOption                
+                value={person.value}
+                disabled={person.disabled}
+              >
+                {person.name}
+              </ComboboxOption>
+            {/each}
+          </ComboboxOptions>
+        </Combobox>                 
+          `);
+
+          // Open combobox
+          await click(getComboboxButton());
+
+          let options: ReturnType<typeof getComboboxOptions>;
+
+          await press(Keys.ArrowDown);
+
+          // Person B should be active
+          options = getComboboxOptions();
+          expect(options[1]).toHaveTextContent("person b");
+          assertActiveComboboxOption(options[1]);
+
+          // Filter more, remove `person a`
+          await type(word("person b"));
+          options = getComboboxOptions();
+          expect(options[0]).toHaveTextContent("person b");
+          assertActiveComboboxOption(options[0]);
+
+          // Filter less, insert `person a` before `person b`
+          await type(word("person"));
+          options = getComboboxOptions();
+          expect(options[1]).toHaveTextContent("person b");
+          assertActiveComboboxOption(options[1]);
+        })
+      );
+    });
+  });
+});
+
+describe("Mouse interactions", () => {
+  it(
+    "should focus the ComboboxInput when we click the ComboboxLabel",
+    suppressConsoleLogs(async () => {
+      render(svelte`
+        <Combobox value="test" on:change={console.log}>
+          <ComboboxLabel>Label</ComboboxLabel>
+          <ComboboxInput on:change={NOOP} />
+          <ComboboxButton>Trigger</ComboboxButton>
+          <ComboboxOptions>
+            <ComboboxOption value="a">Option A</ComboboxOption>
+            <ComboboxOption value="b">Option B</ComboboxOption>
+            <ComboboxOption value="c">Option C</ComboboxOption>
+          </ComboboxOptions>
+        </Combobox>
+      `);
+
+      // Ensure the button is not focused yet
+      assertActiveElement(document.body);
+
+      // Focus the label
+      await click(getComboboxLabel());
+
+      // Ensure that the actual button is focused instead
+      assertActiveElement(getComboboxInput());
+    })
+  );
+
+  it(
+    "should not focus the ComboboxInput when we right click the ComboboxLabel",
+    suppressConsoleLogs(async () => {
+      render(svelte`
+        <Combobox value="test" on:change={console.log}>
+          <ComboboxLabel>Label</ComboboxLabel>
+          <ComboboxInput on:change={NOOP} />
+          <ComboboxButton>Trigger</ComboboxButton>
+          <ComboboxOptions>
+            <ComboboxOption value="a">Option A</ComboboxOption>
+            <ComboboxOption value="b">Option B</ComboboxOption>
+            <ComboboxOption value="c">Option C</ComboboxOption>
+          </ComboboxOptions>
+        </Combobox>
+      `);
+
+      // Ensure the button is not focused yet
+      assertActiveElement(document.body);
+
+      // Focus the label
+      await click(getComboboxLabel(), MouseButton.Right);
+
+      // Ensure that the body is still active
+      assertActiveElement(document.body);
+    })
+  );
+
+  it(
+    "should be possible to open the combobox on click",
+    suppressConsoleLogs(async () => {
+      render(svelte`
+        <Combobox value="test" on:change={console.log}>
+          <ComboboxInput on:change={NOOP} />
+          <ComboboxButton>Trigger</ComboboxButton>
+          <ComboboxOptions>
+            <ComboboxOption value="a">Option A</ComboboxOption>
+            <ComboboxOption value="b">Option B</ComboboxOption>
+            <ComboboxOption value="c">Option C</ComboboxOption>
+          </ComboboxOptions>
+        </Combobox>
+      `);
+
+      assertComboboxButton({
+        state: ComboboxState.InvisibleUnmounted,
+        attributes: { id: "headlessui-combobox-button-2" },
+      });
+      assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+      // Open combobox
+      await click(getComboboxButton());
+
+      // Verify it is visible
+      assertComboboxButton({ state: ComboboxState.Visible });
+      assertComboboxList({
+        state: ComboboxState.Visible,
+        attributes: { id: "headlessui-combobox-options-3" },
+      });
+      assertActiveElement(getComboboxInput());
+      assertComboboxButtonLinkedWithCombobox();
+
+      // Verify we have combobox options
+      let options = getComboboxOptions();
+      expect(options).toHaveLength(3);
+      options.forEach((option) => assertComboboxOption(option));
+    })
+  );
+
+  it(
+    "should not be possible to open the combobox on right click",
+    suppressConsoleLogs(async () => {
+      render(svelte`
+        <Combobox value="test" on:change={console.log}>
+          <ComboboxInput on:change={NOOP} />
+          <ComboboxButton>Trigger</ComboboxButton>
+          <ComboboxOptions>
+            <ComboboxOption value="a">Item A</ComboboxOption>
+            <ComboboxOption value="b">Item B</ComboboxOption>
+            <ComboboxOption value="c">Item C</ComboboxOption>
+          </ComboboxOptions>
+        </Combobox>
+      `);
+
+      assertComboboxButton({
+        state: ComboboxState.InvisibleUnmounted,
+        attributes: { id: "headlessui-combobox-button-2" },
+      });
+      assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+      // Try to open the combobox
+      await click(getComboboxButton(), MouseButton.Right);
+
+      // Verify it is still closed
+      assertComboboxButton({ state: ComboboxState.InvisibleUnmounted });
+    })
+  );
+
+  it(
+    "should not be possible to open the combobox on click when the button is disabled",
+    suppressConsoleLogs(async () => {
+      render(svelte`
+        <Combobox value={undefined} on:change={console.log} disabled>
+          <ComboboxInput on:change={NOOP} />
+          <ComboboxButton>Trigger</ComboboxButton>
+          <ComboboxOptions>
+            <ComboboxOption value="a">Option A</ComboboxOption>
+            <ComboboxOption value="b">Option B</ComboboxOption>
+            <ComboboxOption value="c">Option C</ComboboxOption>
+          </ComboboxOptions>
+        </Combobox>
+      `);
+
+      assertComboboxButton({
+        state: ComboboxState.InvisibleUnmounted,
+        attributes: { id: "headlessui-combobox-button-2" },
+      });
+      assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+      // Try to open the combobox
+      await click(getComboboxButton());
+
+      // Verify it is still closed
+      assertComboboxButton({
+        state: ComboboxState.InvisibleUnmounted,
+        attributes: { id: "headlessui-combobox-button-2" },
+      });
+      assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+    })
+  );
+
+  it(
+    "should be possible to open the combobox on click, and focus the selected option",
+    suppressConsoleLogs(async () => {
+      render(svelte`
+        <Combobox value="b" on:change={console.log}>
+          <ComboboxInput on:change={NOOP} />
+          <ComboboxButton>Trigger</ComboboxButton>
+          <ComboboxOptions>
+            <ComboboxOption value="a">Option A</ComboboxOption>
+            <ComboboxOption value="b">Option B</ComboboxOption>
+            <ComboboxOption value="c">Option C</ComboboxOption>
+          </ComboboxOptions>
+        </Combobox>
+      `);
+
+      assertComboboxButton({
+        state: ComboboxState.InvisibleUnmounted,
+        attributes: { id: "headlessui-combobox-button-2" },
+      });
+      assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+      // Open combobox
+      await click(getComboboxButton());
+
+      // Verify it is visible
+      assertComboboxButton({ state: ComboboxState.Visible });
+      assertComboboxList({
+        state: ComboboxState.Visible,
+        attributes: { id: "headlessui-combobox-options-3" },
+      });
+      assertActiveElement(getComboboxInput());
+      assertComboboxButtonLinkedWithCombobox();
+
+      // Verify we have combobox options
+      let options = getComboboxOptions();
+      expect(options).toHaveLength(3);
+      options.forEach((option, i) =>
+        assertComboboxOption(option, { selected: i === 1 })
+      );
+
+      // Verify that the second combobox option is active (because it is already selected)
+      assertActiveComboboxOption(options[1]);
+    })
+  );
+
+  it(
+    "should be possible to close a combobox on click",
+    suppressConsoleLogs(async () => {
+      render(svelte`
+        <Combobox value="test" on:change={console.log}>
+          <ComboboxInput on:change={NOOP} />
+          <ComboboxButton>Trigger</ComboboxButton>
+          <ComboboxOptions>
+            <ComboboxOption value="a">Option A</ComboboxOption>
+            <ComboboxOption value="b">Option B</ComboboxOption>
+            <ComboboxOption value="c">Option C</ComboboxOption>
+          </ComboboxOptions>
+        </Combobox>
+      `);
+
+      // Open combobox
+      await click(getComboboxButton());
+
+      // Verify it is visible
+      assertComboboxButton({ state: ComboboxState.Visible });
+
+      // Click to close
+      await click(getComboboxButton());
+
+      // Verify it is closed
+      assertComboboxButton({ state: ComboboxState.InvisibleUnmounted });
+      assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+    })
+  );
+
+  it(
+    "should be a no-op when we click outside of a closed combobox",
+    suppressConsoleLogs(async () => {
+      render(svelte`
+        <Combobox value="test" on:change={console.log}>
+          <ComboboxInput on:change={NOOP} />
+          <ComboboxButton>Trigger</ComboboxButton>
+          <ComboboxOptions>
+            <ComboboxOption value="alice">alice</ComboboxOption>
+            <ComboboxOption value="bob">bob</ComboboxOption>
+            <ComboboxOption value="charlie">charlie</ComboboxOption>
+          </ComboboxOptions>
+        </Combobox>
+      `);
+
+      // Verify that the window is closed
+      assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+      // Click something that is not related to the combobox
+      await click(document.body);
+
+      // Should still be closed
+      assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+    })
+  );
+
+  // TODO: JSDOM doesn't quite work here
+  // Clicking outside on the body should fire a mousedown (which it does) and then change the active element (which it doesn't)
+  xit(
+    "should be possible to click outside of the combobox which should close the combobox",
+    suppressConsoleLogs(async () => {
+      render(svelte`        
+        <Combobox value="test" on:change={console.log}>
+          <ComboboxInput on:change={NOOP} />
+          <ComboboxButton>Trigger</ComboboxButton>
+          <ComboboxOptions>
+            <ComboboxOption value="alice">alice</ComboboxOption>
+            <ComboboxOption value="bob">bob</ComboboxOption>
+            <ComboboxOption value="charlie">charlie</ComboboxOption>
+          </ComboboxOptions>
+        </Combobox>
+        <div tabIndex={-1} data-test-focusable>
+          after
+        </div>        
+      `);
+
+      // Open combobox
+      await click(getComboboxButton());
+      assertComboboxList({ state: ComboboxState.Visible });
+      assertActiveElement(getComboboxInput());
+
+      // Click something that is not related to the combobox
+      await click(getByText("after"));
+
+      // Should be closed now
+      assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+      // Verify the button is focused
+      assertActiveElement(getByText("after"));
+    })
+  );
+
+  it(
+    "should be possible to click outside of the combobox on another combobox button which should close the current combobox and open the new combobox",
+    suppressConsoleLogs(async () => {
+      render(svelte`
+        <div>
+          <Combobox value="test" on:change={console.log}>
+            <ComboboxInput on:change={NOOP} />
+            <ComboboxButton>Trigger</ComboboxButton>
+            <ComboboxOptions>
+              <ComboboxOption value="alice">alice</ComboboxOption>
+              <ComboboxOption value="bob">bob</ComboboxOption>
+              <ComboboxOption value="charlie">charlie</ComboboxOption>
+            </ComboboxOptions>
+          </Combobox>
+
+          <Combobox value="test" on:change={console.log}>
+            <ComboboxInput on:change={NOOP} />
+            <ComboboxButton>Trigger</ComboboxButton>
+            <ComboboxOptions>
+              <ComboboxOption value="alice">alice</ComboboxOption>
+              <ComboboxOption value="bob">bob</ComboboxOption>
+              <ComboboxOption value="charlie">charlie</ComboboxOption>
+            </ComboboxOptions>
+          </Combobox>
+        </div>
+      `);
+
+      let [button1, button2] = getComboboxButtons();
+
+      // Click the first combobox button
+      await click(button1);
+      expect(getComboboxes()).toHaveLength(1); // Only 1 combobox should be visible
+
+      // Verify that the first input is focused
+      assertActiveElement(getComboboxInputs()[0]);
+
+      // Click the second combobox button
+      await click(button2);
+
+      expect(getComboboxes()).toHaveLength(1); // Only 1 combobox should be visible
+
+      // Verify that the first input is focused
+      assertActiveElement(getComboboxInputs()[1]);
+    })
+  );
+
+  it(
+    "should be possible to click outside of the combobox which should close the combobox (even if we press the combobox button)",
+    suppressConsoleLogs(async () => {
+      render(svelte`
+        <Combobox value="test" on:change={console.log}>
+          <ComboboxInput on:change={NOOP} />
+          <ComboboxButton>Trigger</ComboboxButton>
+          <ComboboxOptions>
+            <ComboboxOption value="alice">alice</ComboboxOption>
+            <ComboboxOption value="bob">bob</ComboboxOption>
+            <ComboboxOption value="charlie">charlie</ComboboxOption>
+          </ComboboxOptions>
+        </Combobox>
+      `);
+
+      // Open combobox
+      await click(getComboboxButton());
+      assertComboboxList({ state: ComboboxState.Visible });
+      assertActiveElement(getComboboxInput());
+
+      // Click the combobox button again
+      await click(getComboboxButton());
+
+      // Should be closed now
+      assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+      // Verify the input is focused again
+      assertActiveElement(getComboboxInput());
+    })
+  );
+
+  it(
+    "should be possible to click outside of the combobox, on an element which is within a focusable element, which closes the combobox",
+    suppressConsoleLogs(async () => {
+      let focusFn = jest.fn();
+      render(svelte`
+        <div>
+          <Combobox value="test" on:change={console.log}>
+            <ComboboxInput on:change={NOOP} onFocus={focusFn} />
+            <ComboboxButton>Trigger</ComboboxButton>
+            <ComboboxOptions>
+              <ComboboxOption value="alice">alice</ComboboxOption>
+              <ComboboxOption value="bob">bob</ComboboxOption>
+              <ComboboxOption value="charlie">charlie</ComboboxOption>
+            </ComboboxOptions>
+          </Combobox>
+
+          <button id="btn">
+            <span>Next</span>
+          </button>
+        </div>
+      `);
+
+      // Click the combobox button
+      await click(getComboboxButton());
+
+      // Ensure the combobox is open
+      assertComboboxList({ state: ComboboxState.Visible });
+
+      // Click the span inside the button
+      await click(getByText("Next"));
+
+      // Ensure the combobox is closed
+      assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+      // Ensure the outside button is focused
+      assertActiveElement(document.getElementById("btn"));
+
+      // Ensure that the focus button only got focus once (first click)
+      expect(focusFn).toHaveBeenCalledTimes(1);
+    })
+  );
+
+  it(
+    "should be possible to hover an option and make it active",
+    suppressConsoleLogs(async () => {
+      render(svelte`
+        <Combobox value="test" on:change={console.log}>
+          <ComboboxInput on:change={NOOP} />
+          <ComboboxButton>Trigger</ComboboxButton>
+          <ComboboxOptions>
+            <ComboboxOption value="alice">alice</ComboboxOption>
+            <ComboboxOption value="bob">bob</ComboboxOption>
+            <ComboboxOption value="charlie">charlie</ComboboxOption>
+          </ComboboxOptions>
+        </Combobox>
+      `);
+
+      // Open combobox
+      await click(getComboboxButton());
+
+      let options = getComboboxOptions();
+      // We should be able to go to the second option
+      await mouseMove(options[1]);
+      assertActiveComboboxOption(options[1]);
+
+      // We should be able to go to the first option
+      await mouseMove(options[0]);
+      assertActiveComboboxOption(options[0]);
+
+      // We should be able to go to the last option
+      await mouseMove(options[2]);
+      assertActiveComboboxOption(options[2]);
+    })
+  );
+
+  it(
+    "should be possible to hover an option and make it active when using `static`",
+    suppressConsoleLogs(async () => {
+      render(svelte`
+        <Combobox value="test" on:change={console.log}>
+          <ComboboxInput on:change={NOOP} />
+          <ComboboxButton>Trigger</ComboboxButton>
+          <ComboboxOptions static>
+            <ComboboxOption value="alice">alice</ComboboxOption>
+            <ComboboxOption value="bob">bob</ComboboxOption>
+            <ComboboxOption value="charlie">charlie</ComboboxOption>
+          </ComboboxOptions>
+        </Combobox>
+      `);
+
+      let options = getComboboxOptions();
+      // We should be able to go to the second option
+      await mouseMove(options[1]);
+      assertActiveComboboxOption(options[1]);
+
+      // We should be able to go to the first option
+      await mouseMove(options[0]);
+      assertActiveComboboxOption(options[0]);
+
+      // We should be able to go to the last option
+      await mouseMove(options[2]);
+      assertActiveComboboxOption(options[2]);
+    })
+  );
+
+  it(
+    "should make a combobox option active when you move the mouse over it",
+    suppressConsoleLogs(async () => {
+      render(svelte`
+        <Combobox value="test" on:change={console.log}>
+          <ComboboxInput on:change={NOOP} />
+          <ComboboxButton>Trigger</ComboboxButton>
+          <ComboboxOptions>
+            <ComboboxOption value="alice">alice</ComboboxOption>
+            <ComboboxOption value="bob">bob</ComboboxOption>
+            <ComboboxOption value="charlie">charlie</ComboboxOption>
+          </ComboboxOptions>
+        </Combobox>
+      `);
+
+      // Open combobox
+      await click(getComboboxButton());
+
+      let options = getComboboxOptions();
+      // We should be able to go to the second option
+      await mouseMove(options[1]);
+      assertActiveComboboxOption(options[1]);
+    })
+  );
+
+  it(
+    "should be a no-op when we move the mouse and the combobox option is already active",
+    suppressConsoleLogs(async () => {
+      render(svelte`
+        <Combobox value="test" on:change={console.log}>
+          <ComboboxInput on:change={NOOP} />
+          <ComboboxButton>Trigger</ComboboxButton>
+          <ComboboxOptions>
+            <ComboboxOption value="alice">alice</ComboboxOption>
+            <ComboboxOption value="bob">bob</ComboboxOption>
+            <ComboboxOption value="charlie">charlie</ComboboxOption>
+          </ComboboxOptions>
+        </Combobox>
+      `);
+
+      // Open combobox
+      await click(getComboboxButton());
+
+      let options = getComboboxOptions();
+
+      // We should be able to go to the second option
+      await mouseMove(options[1]);
+      assertActiveComboboxOption(options[1]);
+
+      await mouseMove(options[1]);
+
+      // Nothing should be changed
+      assertActiveComboboxOption(options[1]);
+    })
+  );
+
+  it(
+    "should be a no-op when we move the mouse and the combobox option is disabled",
+    suppressConsoleLogs(async () => {
+      render(svelte`
+        <Combobox value="test" on:change={console.log}>
+          <ComboboxInput on:change={NOOP} />
+          <ComboboxButton>Trigger</ComboboxButton>
+          <ComboboxOptions>
+            <ComboboxOption value="alice">alice</ComboboxOption>
+            <ComboboxOption disabled value="bob">
+              bob
+            </ComboboxOption>
+            <ComboboxOption value="charlie">charlie</ComboboxOption>
+          </ComboboxOptions>
+        </Combobox>
+      `);
+
+      // Open combobox
+      await click(getComboboxButton());
+
+      let options = getComboboxOptions();
+
+      await mouseMove(options[1]);
+      assertNotActiveComboboxOption(options[1]);
+    })
+  );
+
+  it(
+    "should not be possible to hover an option that is disabled",
+    suppressConsoleLogs(async () => {
+      render(svelte`
+        <Combobox value="test" on:change={console.log}>
+          <ComboboxInput on:change={NOOP} />
+          <ComboboxButton>Trigger</ComboboxButton>
+          <ComboboxOptions>
+            <ComboboxOption value="alice">alice</ComboboxOption>
+            <ComboboxOption disabled value="bob">
+              bob
+            </ComboboxOption>
+            <ComboboxOption value="charlie">charlie</ComboboxOption>
+          </ComboboxOptions>
+        </Combobox>
+      `);
+
+      // Open combobox
+      await click(getComboboxButton());
+
+      let options = getComboboxOptions();
+
+      // Try to hover over option 1, which is disabled
+      await mouseMove(options[1]);
+
+      // We should not have option 1 as the active option now
+      assertNotActiveComboboxOption(options[1]);
+    })
+  );
+
+  it(
+    "should be possible to mouse leave an option and make it inactive",
+    suppressConsoleLogs(async () => {
+      render(svelte`
+        <Combobox value="bob" on:change={console.log}>
+          <ComboboxInput on:change={NOOP} />
+          <ComboboxButton>Trigger</ComboboxButton>
+          <ComboboxOptions>
+            <ComboboxOption value="alice">alice</ComboboxOption>
+            <ComboboxOption value="bob">bob</ComboboxOption>
+            <ComboboxOption value="charlie">charlie</ComboboxOption>
+          </ComboboxOptions>
+        </Combobox>
+      `);
+
+      // Open combobox
+      await click(getComboboxButton());
+
+      let options = getComboboxOptions();
+
+      // We should be able to go to the second option
+      await mouseMove(options[1]);
+      assertActiveComboboxOption(options[1]);
+
+      await mouseLeave(options[1]);
+      assertNoActiveComboboxOption();
+
+      // We should be able to go to the first option
+      await mouseMove(options[0]);
+      assertActiveComboboxOption(options[0]);
+
+      await mouseLeave(options[0]);
+      assertNoActiveComboboxOption();
+
+      // We should be able to go to the last option
+      await mouseMove(options[2]);
+      assertActiveComboboxOption(options[2]);
+
+      await mouseLeave(options[2]);
+      assertNoActiveComboboxOption();
+    })
+  );
+
+  it(
+    "should be possible to mouse leave a disabled option and be a no-op",
+    suppressConsoleLogs(async () => {
+      render(svelte`
+        <Combobox value="test" on:change={console.log}>
+          <ComboboxInput on:change={NOOP} />
+          <ComboboxButton>Trigger</ComboboxButton>
+          <ComboboxOptions>
+            <ComboboxOption value="alice">alice</ComboboxOption>
+            <ComboboxOption disabled value="bob">
+              bob
+            </ComboboxOption>
+            <ComboboxOption value="charlie">charlie</ComboboxOption>
+          </ComboboxOptions>
+        </Combobox>
+      `);
+
+      // Open combobox
+      await click(getComboboxButton());
+
+      let options = getComboboxOptions();
+
+      // Try to hover over option 1, which is disabled
+      await mouseMove(options[1]);
+      assertNotActiveComboboxOption(options[1]);
+
+      await mouseLeave(options[1]);
+      assertNotActiveComboboxOption(options[1]);
+    })
+  );
+
+  it(
+    "should be possible to click a combobox option, which closes the combobox",
+    suppressConsoleLogs(async () => {
+      let handleChange = jest.fn();      
+
+      render(svelte`
+      <script>
+        let value
+      </script>
+
+      <Combobox
+        value={value}
+        on:change={(e) => {
+          value = e.detail;
+          handleChange(e.detail);
+        }}
+      >
+        <ComboboxInput on:change={NOOP} />
+        <ComboboxButton>Trigger</ComboboxButton>
+        <ComboboxOptions>
+          <ComboboxOption value="alice">alice</ComboboxOption>
+          <ComboboxOption value="bob">bob</ComboboxOption>
+          <ComboboxOption value="charlie">charlie</ComboboxOption>
+        </ComboboxOptions>
+      </Combobox>
+      `);
+
+      // Open combobox
+      await click(getComboboxButton());
+      assertComboboxList({ state: ComboboxState.Visible });
+      assertActiveElement(getComboboxInput());
+
+      let options = getComboboxOptions();
+
+      // We should be able to click the first option
+      await click(options[1]);
+      assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+      expect(handleChange).toHaveBeenCalledTimes(1);
+      expect(handleChange).toHaveBeenCalledWith("bob");
+
+      // Verify the input is focused again
+      assertActiveElement(getComboboxInput());
+
+      // Open combobox again
+      await click(getComboboxButton());
+
+      // Verify the active option is the previously selected one
+      assertActiveComboboxOption(getComboboxOptions()[1]);
+    })
+  );
+
+  it(
+    "should be possible to click a disabled combobox option, which is a no-op",
+    suppressConsoleLogs(async () => {
+      let handleChange = jest.fn();     
+
+      render(svelte`
+      <script>
+        let value
+      </script>
+
+      <Combobox
+        value={value}
+        on:change={(e) => {
+          value = e.detail;
+          handleChange(e.detail);
+        }}
+      >
+        <ComboboxInput on:change={NOOP} />
+        <ComboboxButton>Trigger</ComboboxButton>
+        <ComboboxOptions>
+          <ComboboxOption value="alice">alice</ComboboxOption>
+          <ComboboxOption value="bob" disabled>bob</ComboboxOption>
+          <ComboboxOption value="charlie">charlie</ComboboxOption>
+        </ComboboxOptions>
+      </Combobox>
+      `);
+
+      // Open combobox
+      await click(getComboboxButton());
+      assertComboboxList({ state: ComboboxState.Visible });
+      assertActiveElement(getComboboxInput());
+
+      let options = getComboboxOptions();
+
+      // We should not be able to click the disabled option
+      await click(options[1]);
+      assertComboboxList({ state: ComboboxState.Visible });
+      assertNotActiveComboboxOption(options[1]);
+      assertActiveElement(getComboboxInput());
+      expect(handleChange).toHaveBeenCalledTimes(0);
+
+      // Close the combobox
+      await click(getComboboxButton());
+
+      // Open combobox again
+      await click(getComboboxButton());
+
+      options = getComboboxOptions();
+
+      // Verify the active option is not the disabled one
+      assertNotActiveComboboxOption(options[1]);
+    })
+  );
+
+  it(
+    "should be possible focus a combobox option, so that it becomes active",
+    suppressConsoleLogs(async () => {
+      render(svelte`
+        <script>
+          let value
+        </script>
+
+        <Combobox
+          value={value}
+          on:change={(e) => {
+            value = e.detail;
+            handleChange(e.detail);
+          }}
+        >
+          <ComboboxInput on:change={NOOP} />
+          <ComboboxButton>Trigger</ComboboxButton>
+          <ComboboxOptions>
+            <ComboboxOption value="alice">alice</ComboboxOption>
+            <ComboboxOption value="bob">bob</ComboboxOption>
+            <ComboboxOption value="charlie">charlie</ComboboxOption>
+          </ComboboxOptions>
+        </Combobox>
+      `);
+
+      // Open combobox
+      await click(getComboboxButton());
+      assertComboboxList({ state: ComboboxState.Visible });
+      assertActiveElement(getComboboxInput());
+
+      let options = getComboboxOptions();
+
+      // Verify that the first item is active
+      assertActiveComboboxOption(options[0]);
+
+      // We should be able to focus the second option
+      await focus(options[1]);
+      assertActiveComboboxOption(options[1]);
+    })
+  );
+
+  it(
+    "should not be possible to focus a combobox option which is disabled",
+    suppressConsoleLogs(async () => {
+      render(svelte`
+        <Combobox value="test" on:change={console.log}>
+          <ComboboxInput on:change={NOOP} />
+          <ComboboxButton>Trigger</ComboboxButton>
+          <ComboboxOptions>
+            <ComboboxOption value="alice">alice</ComboboxOption>
+            <ComboboxOption disabled value="bob">
+              bob
+            </ComboboxOption>
+            <ComboboxOption value="charlie">charlie</ComboboxOption>
+          </ComboboxOptions>
+        </Combobox>
+      `);
+
+      // Open combobox
+      await click(getComboboxButton());
+      assertComboboxList({ state: ComboboxState.Visible });
+      assertActiveElement(getComboboxInput());
+
+      let options = getComboboxOptions();
+
+      // We should not be able to focus the first option
+      await focus(options[1]);
+      assertNotActiveComboboxOption(options[1]);
+    })
+  );
+
+  it(
+    "should be possible to hold the last active option",
+    suppressConsoleLogs(async () => {
+      render(svelte`
+        <Combobox value="test" on:change={console.log}>
+          <ComboboxInput on:change={NOOP} />
+          <ComboboxButton>Trigger</ComboboxButton>
+          <ComboboxOptions hold>
+            <ComboboxOption value="a">Option A</ComboboxOption>
+            <ComboboxOption value="b">Option B</ComboboxOption>
+            <ComboboxOption value="c">Option C</ComboboxOption>
+          </ComboboxOptions>
+        </Combobox>
+      `);
+
+      assertComboboxButton({
+        state: ComboboxState.InvisibleUnmounted,
+        attributes: { id: "headlessui-combobox-button-2" },
+      });
+      assertComboboxList({ state: ComboboxState.InvisibleUnmounted });
+
+      await click(getComboboxButton());
+
+      assertComboboxButton({
+        state: ComboboxState.Visible,
+        attributes: { id: "headlessui-combobox-button-2" },
+      });
+      assertComboboxList({ state: ComboboxState.Visible });
+
+      let options = getComboboxOptions();
+
+      // Hover the first item
+      await mouseMove(options[0]);
+
+      // Verify that the first combobox option is active
+      assertActiveComboboxOption(options[0]);
+
+      // Focus the second item
+      await mouseMove(options[1]);
+
+      // Verify that the second combobox option is active
+      assertActiveComboboxOption(options[1]);
+
+      // Move the mouse off of the second combobox option
+      await mouseLeave(options[1]);
+      await mouseMove(document.body);
+
+      // Verify that the second combobox option is still active
+      assertActiveComboboxOption(options[1]);
+    })
+  );
+
+  it(
+    "should sync the input field correctly and reset it when resetting the value from outside",
+    suppressConsoleLogs(async () => {     
+
+      render(svelte`
+      <script>
+        let value = "bob"
+      </script>
+
+      <Combobox
+        value={value}
+        on:change={(e) => { value = e.detail }}
+      >
+        <ComboboxInput on:change={NOOP} />
+        <ComboboxButton>Trigger</ComboboxButton>
+        <ComboboxOptions>
+          <ComboboxOption value="alice">alice</ComboboxOption>
+          <ComboboxOption value="bob">bob</ComboboxOption>
+          <ComboboxOption value="charlie">charlie</ComboboxOption>
+        </ComboboxOptions>
+      </Combobox>
+      <button on:click={(e) => value = null}>reset</button>
+      `);
+
+      // Open combobox
+      await click(getComboboxButton());
+
+      // Verify the input has the selected value
+      expect(getComboboxInput()?.value).toBe("bob");
+
+      // Override the input by typing something
+      await type(word("test"), getComboboxInput());
+      expect(getComboboxInput()?.value).toBe("test");
+
+      // Reset from outside
+      await click(getByText("reset"));
+
+      // Verify the input is reset correctly
+      expect(getComboboxInput()?.value).toBe("");
+    })
+  );
+
+  it(
+    "should sync the input field correctly and reset it when resetting the value from outside (when using displayValue)",
+    suppressConsoleLogs(async () => {      
+      render(svelte`
+        <script>
+          let people = [
+            { id: 1, name: "Alice" },
+            { id: 2, name: "Bob" },
+            { id: 3, name: "Charlie" },
+          ];
+
+          let value = people[1]
+
+        </script>
+
+        <Combobox value={value} on:change={(e) => value = e.detail }>
+        <ComboboxInput
+          on:change={NOOP}
+          displayValue={(person) => person?.name}
+        />
+        <ComboboxButton>Trigger</ComboboxButton>
+        <ComboboxOptions>
+          {#each people as person}          
+            <ComboboxOption value={person}>
+              {person.name}
+            </ComboboxOption>
+          {/each}
+        </ComboboxOptions>
+      </Combobox>
+      <button on:click={(e) => value = null}>reset</button>
+      `);
+
+      // Open combobox
+      await click(getComboboxButton());
+
+      // Verify the input has the selected value
+      expect(getComboboxInput()?.value).toBe("Bob");
+
+      // Override the input by typing something
+      await type(word("test"), getComboboxInput());
+      expect(getComboboxInput()?.value).toBe("test");
+
+      // Reset from outside
+      await click(getByText("reset"));
+
+      // Verify the input is reset correctly
+      expect(getComboboxInput()?.value).toBe("");
+    })
+  );
+});
+
+describe("Multi-select", () => {
+  it(
+    "should be possible to pass multiple values to the Combobox component",
+    suppressConsoleLogs(async () => {      
+
+      render(svelte`
+        <script>
+          let value = ["bob", "charlie"]
+        </script>
+
+        <Combobox
+        value={value}
+        on:change={(e) => value = e.detail}
+        multiple
+      >
+        <ComboboxInput on:change={() => {}} />
+        <ComboboxButton>Trigger</ComboboxButton>
+        <ComboboxOptions>
+          <ComboboxOption value="alice">alice</ComboboxOption>
+          <ComboboxOption value="bob">bob</ComboboxOption>
+          <ComboboxOption value="charlie">charlie</ComboboxOption>
+        </ComboboxOptions>
+      </Combobox>
+      `);
+
+      // Open combobox
+      await click(getComboboxButton());
+
+      // Verify that we have an open combobox with multiple mode
+      assertCombobox({
+        state: ComboboxState.Visible,
+        mode: ComboboxMode.Multiple,
+      });
+
+      // Verify that we have multiple selected combobox options
+      let options = getComboboxOptions();
+
+      assertComboboxOption(options[0], { selected: false });
+      assertComboboxOption(options[1], { selected: true });
+      assertComboboxOption(options[2], { selected: true });
+    })
+  );
+
+  it(
+    "should make the first selected option the active item",
+    suppressConsoleLogs(async () => {             
+
+      render(svelte`
+        <script>
+          let value = ["bob", "charlie"]
+        </script>
+
+        <Combobox
+        value={value}
+        on:change={(e) => value = e.detail}
+        multiple
+      >
+        <ComboboxInput on:change={() => {}} />
+        <ComboboxButton>Trigger</ComboboxButton>
+        <ComboboxOptions>
+          <ComboboxOption value="alice">alice</ComboboxOption>
+          <ComboboxOption value="bob">bob</ComboboxOption>
+          <ComboboxOption value="charlie">charlie</ComboboxOption>
+        </ComboboxOptions>
+      </Combobox>
+      `);
+
+      // Open combobox
+      await click(getComboboxButton());
+
+      // Verify that bob is the active option
+      assertActiveComboboxOption(getComboboxOptions()[1]);
+    })
+  );
+
+  it(
+    "should keep the combobox open when selecting an item via the keyboard",
+    suppressConsoleLogs(async () => {      
+
+      render(svelte`
+        <script>
+          let value = ["bob", "charlie"]
+        </script>
+
+        <Combobox
+        value={value}
+        on:change={(e) => value = e.detail}
+        multiple
+      >
+        <ComboboxInput on:change={() => {}} />
+        <ComboboxButton>Trigger</ComboboxButton>
+        <ComboboxOptions>
+          <ComboboxOption value="alice">alice</ComboboxOption>
+          <ComboboxOption value="bob">bob</ComboboxOption>
+          <ComboboxOption value="charlie">charlie</ComboboxOption>
+        </ComboboxOptions>
+      </Combobox>
+      `);
+
+      // Open combobox
+      await click(getComboboxButton());
+      assertCombobox({ state: ComboboxState.Visible });
+
+      // Verify that bob is the active option
+      await click(getComboboxOptions()[0]);
+
+      // Verify that the combobox is still open
+      assertCombobox({ state: ComboboxState.Visible });
+    })
+  );
+
+  it(
+    "should toggle the selected state of an option when clicking on it",
+    suppressConsoleLogs(async () => {
+      render(svelte`
+        <script>
+          let value = ["bob", "charlie"]
+        </script>
+
+        <Combobox
+        value={value}
+        on:change={(e) => value = e.detail}
+        multiple
+      >
+        <ComboboxInput on:change={() => {}} />
+        <ComboboxButton>Trigger</ComboboxButton>
+        <ComboboxOptions>
+          <ComboboxOption value="alice">alice</ComboboxOption>
+          <ComboboxOption value="bob">bob</ComboboxOption>
+          <ComboboxOption value="charlie">charlie</ComboboxOption>
+        </ComboboxOptions>
+      </Combobox>
+      `);
+
+      // Open combobox
+      await click(getComboboxButton());
+      assertCombobox({ state: ComboboxState.Visible });
+
+      let options = getComboboxOptions();
+
+      assertComboboxOption(options[0], { selected: false });
+      assertComboboxOption(options[1], { selected: true });
+      assertComboboxOption(options[2], { selected: true });
+
+      // Click on bob
+      await click(getComboboxOptions()[1]);
+
+      assertComboboxOption(options[0], { selected: false });
+      assertComboboxOption(options[1], { selected: false });
+      assertComboboxOption(options[2], { selected: true });
+
+      // Click on bob again
+      await click(getComboboxOptions()[1]);
+
+      assertComboboxOption(options[0], { selected: false });
+      assertComboboxOption(options[1], { selected: true });
+      assertComboboxOption(options[2], { selected: true });
+    })
+  );
+});
+
+describe("Form compatibility", () => {
+  it("should be possible to submit a form with a value", async () => {
+    let submits = jest.fn();
+
+    render(svelte`
+      <script>
+        let value
+      </script>
+
+      <form
+        on:submit|preventDefault={(event) => {          
+          submits([...new FormData(event.currentTarget).entries()]);
+        }}
+      >
+        <Combobox value={value} on:change={(e) => value = e.detail} name="delivery">
+          <ComboboxInput on:change={console.log} />
+          <ComboboxButton>Trigger</ComboboxButton>
+          <ComboboxLabel>Pizza Delivery</ComboboxLabel>
+          <ComboboxOptions>
+            <ComboboxOption value="pickup">Pickup</ComboboxOption>
+            <ComboboxOption value="home-delivery">
+              Home delivery
+            </ComboboxOption>
+            <ComboboxOption value="dine-in">Dine in</ComboboxOption>
+          </ComboboxOptions>
+        </Combobox>
+        <button>Submit</button>
+      </form>
+    `);
+
+    // Open combobox
+    await click(getComboboxButton());
+
+    // Submit the form
+    await click(getByText("Submit"));
+
+    // Verify that the form has been submitted
+    expect(submits).lastCalledWith([]); // no data
+
+    // Open combobox again
+    await click(getComboboxButton());
+
+    // Choose home delivery
+    await click(getByText("Home delivery"));
+
+    // Submit the form again
+    await click(getByText("Submit"));
+
+    // Verify that the form has been submitted
+    expect(submits).lastCalledWith([["delivery", "home-delivery"]]);
+
+    // Open combobox again
+    await click(getComboboxButton());
+
+    // Choose pickup
+    await click(getByText("Pickup"));
+
+    // Submit the form again
+    await click(getByText("Submit"));
+
+    // Verify that the form has been submitted
+    expect(submits).lastCalledWith([["delivery", "pickup"]]);
+  });
+
+  it("should be possible to submit a form with a complex value object", async () => {
+    let submits = jest.fn();    
+
+    render(svelte`
+      <script>
+        let options = [
+          {
+            id: 1,
+            value: "pickup",
+            label: "Pickup",
+            extra: { info: "Some extra info" },
+          },
+          {
+            id: 2,
+            value: "home-delivery",
+            label: "Home delivery",
+            extra: { info: "Some extra info" },
+          },
+          {
+            id: 3,
+            value: "dine-in",
+            label: "Dine in",
+            extra: { info: "Some extra info" },
+          },
+        ];
+        let value = options[0]
+      </script>
+      <form
+        on:submit|preventDefault={(event) => {          
+          submits([...new FormData(event.currentTarget).entries()]);
+        }}
+      >
+        <Combobox value={value} on:change={(e) => value = e.detail} name="delivery">
+          <ComboboxInput on:change={console.log} />
+          <ComboboxButton>Trigger</ComboboxButton>
+          <ComboboxLabel>Pizza Delivery</ComboboxLabel>
+          <ComboboxOptions>
+            {#each options as option (option)}            
+              <ComboboxOption value={option}>
+                {option.label}
+              </ComboboxOption>
+            {/each}
+          </ComboboxOptions>
+        </Combobox>
+        <button>Submit</button>
+      </form>
+    `);
+
+    // Open combobox
+    await click(getComboboxButton());
+
+    // Submit the form
+    await click(getByText("Submit"));
+
+    // Verify that the form has been submitted
+    expect(submits).lastCalledWith([
+      ["delivery[id]", "1"],
+      ["delivery[value]", "pickup"],
+      ["delivery[label]", "Pickup"],
+      ["delivery[extra][info]", "Some extra info"],
+    ]);
+
+    // Open combobox
+    await click(getComboboxButton());
+
+    await nextFrame()
+    // Choose home delivery
+    await click(getByText("Home delivery"));
+
+    // Submit the form again
+    await click(getByText("Submit"));
+
+    // Verify that the form has been submitted
+    expect(submits).lastCalledWith([
+      ["delivery[id]", "2"],
+      ["delivery[value]", "home-delivery"],
+      ["delivery[label]", "Home delivery"],
+      ["delivery[extra][info]", "Some extra info"],
+    ]);
+
+    // Open combobox
+    await click(getComboboxButton());
+
+    // Choose pickup
+    await click(getByText("Pickup"));
+
+    // Submit the form again
+    await click(getByText("Submit"));
+
+    // Verify that the form has been submitted
+    expect(submits).lastCalledWith([
+      ["delivery[id]", "1"],
+      ["delivery[value]", "pickup"],
+      ["delivery[label]", "Pickup"],
+      ["delivery[extra][info]", "Some extra info"],
+    ]);
+  });
+});

--- a/src/lib/components/combobox/index.ts
+++ b/src/lib/components/combobox/index.ts
@@ -1,0 +1,6 @@
+export { default as Combobox } from "./Combobox.svelte";
+export { default as ComboboxButton } from "./ComboboxButton.svelte";
+export { default as ComboboxLabel } from "./ComboboxLabel.svelte";
+export { default as ComboboxInput } from "./ComboboxInput.svelte";
+export { default as ComboboxOptions } from "./ComboboxOptions.svelte";
+export { default as ComboboxOption } from "./ComboboxOption.svelte";

--- a/src/lib/components/listbox/Listbox.svelte
+++ b/src/lib/components/listbox/Listbox.svelte
@@ -61,6 +61,8 @@
     horizontal?: boolean;
     /** The selected value */
     value?: StateDefinition["value"];
+    /** The name used when using this component inside a form. */
+    name?: string;
   };
 </script>
 
@@ -80,6 +82,8 @@
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
   import Render from "$lib/utils/Render.svelte";
   import type { TPassThroughProps } from "$lib/types";
+  import Hidden, { Features as HiddenFeatures } from "$lib/internal/Hidden.svelte";
+  import { objectToFormEntries } from "$lib/utils/form";
 
   /***** Props *****/
   type TAsProp = $$Generic<SupportedAs>;
@@ -90,6 +94,7 @@
   export let disabled = false;
   export let horizontal = false;
   export let value: StateDefinition["value"];
+  export let name: string | null = null;
 
   /***** Events *****/
   const forwardEvents = forwardEventsBuilder(get_current_component(), [
@@ -276,6 +281,21 @@
 </script>
 
 <svelte:window on:mousedown={handleMousedown} />
+
+{#if name != null && value != null}
+  {@const options = objectToFormEntries({ [name]: value })}
+  {#each options as [optionName, optionValue], index (index)}      
+    <Hidden
+      features={HiddenFeatures.Hidden}
+      as="input"
+      type="hidden"
+      hidden
+      readonly
+      name={optionName}
+      value={optionValue}
+    />
+  {/each}
+{/if}  
 <Render
   {...$$restProps}
   {as}

--- a/src/lib/components/radio-group/RadioGroup.svelte
+++ b/src/lib/components/radio-group/RadioGroup.svelte
@@ -52,6 +52,8 @@
     value: StateDefinition["value"];
     /** Whether the `RadioGroup` and all of its `RadioGroupOption`s are disabled */
     disabled?: boolean;
+    /** The name used when using this component inside a form. */
+    name?: string;
   };
 </script>
 
@@ -63,6 +65,8 @@
   import type { HTMLActionArray } from "$lib/hooks/use-actions";
   import Render from "$lib/utils/Render.svelte";
   import type { TPassThroughProps } from "$lib/types";
+  import Hidden, { Features as HiddenFeatures } from "$lib/internal/Hidden.svelte";
+  import { objectToFormEntries } from "$lib/utils/form";
 
   /***** Props *****/
   type TAsProp = $$Generic<SupportedAs>;
@@ -72,6 +76,7 @@
   export let use: HTMLActionArray = [];
   export let value: StateDefinition["value"];
   export let disabled = false;
+  export let name: string | null = null;
 
   /***** Events *****/
   const forwardEvents = forwardEventsBuilder(get_current_component(), [
@@ -223,6 +228,21 @@
 
 <DescriptionProvider name="RadioGroupDescription" let:describedby>
   <LabelProvider name="RadioGroupLabel" let:labelledby>
+    {#if name != null && value != null}
+      {@const options = objectToFormEntries({ [name]: value })}
+      {#each options as [optionName, optionValue], index (index)}      
+        <Hidden
+          features={HiddenFeatures.Hidden}
+          as="input"
+          type="hidden"
+          hidden
+          readonly
+          name={optionName}
+          value={optionValue}
+        />
+      {/each}
+    {/if}  
+
     <Render
       {...{ ...$$restProps, ...propsWeControl }}
       {as}

--- a/src/lib/components/radio-group/radio-group.test.ts
+++ b/src/lib/components/radio-group/radio-group.test.ts
@@ -771,3 +771,45 @@ describe('Mouse interactions', () => {
     expect(changeFn).toHaveBeenCalledTimes(1)
   })
 })
+
+describe("`Enter`", () => {
+  it("should submit the form on `Enter`", async () => {    
+    let submitFn = jest.fn();
+    
+    render(svelte`   
+      <script>
+        let selected = "home-delivery"
+      </script>
+    
+      <form on:submit={(event) => {
+        event.preventDefault()
+        submitFn([...new FormData(event.currentTarget).entries()])
+      }}>
+        <RadioGroup value={selected} name="option" on:change={(e) => selected = e.detail}>
+          <RadioGroupLabel>Pizza Delivery</RadioGroupLabel>
+          <RadioGroupOption value="pickup">Pickup</RadioGroupOption>
+          <RadioGroupOption value="home-delivery">Home delivery</RadioGroupOption>
+          <RadioGroupOption value="dine-in">Dine in</RadioGroupOption>
+        </RadioGroup>
+        <button type="submit">Submit</button>
+      </form>
+    `);
+
+    // Submit the form
+    await click(getByText('Submit'))   
+
+    // Verify the form was submitted with the home-delivery option
+    expect(submitFn).toHaveBeenCalledTimes(1);
+    expect(submitFn).toHaveBeenCalledWith([["option", "home-delivery"]]);
+
+    // Select the Pickup option
+    await click(getByText("Pickup"));
+
+    // Submit the form
+    await click(getByText('Submit'))   
+
+    // Verify the form was submitted with the pickup option
+    expect(submitFn).toHaveBeenCalledTimes(2);
+    expect(submitFn).toHaveBeenCalledWith([["option", "pickup"]]);
+  });
+});

--- a/src/lib/components/switch/Switch.svelte
+++ b/src/lib/components/switch/Switch.svelte
@@ -5,6 +5,10 @@
   > = TPassThroughProps<TSlotProps, TAsProp, "button"> & {
     /** Whether the switch is checked */
     checked: boolean;
+    /** The name used when using this component inside a form. */
+    name?: string;
+    /** The value used when using this component inside a form, if it is checked. */
+    value?: string;
   };
 </script>
 
@@ -22,6 +26,7 @@
   import Render from "$lib/utils/Render.svelte";
   import { resolveButtonType } from "$lib/utils/resolve-button-type";
   import type { TPassThroughProps } from "$lib/types";
+  import Hidden, { Features as HiddenFeatures } from "$lib/internal/Hidden.svelte";
 
   /***** Props *****/
   type TAsProp = $$Generic<SupportedAs>;
@@ -30,6 +35,8 @@
   export let as: SupportedAs = "button";
   export let use: HTMLActionArray = [];
   export let checked = false;
+  export let name: string | null = null;
+  export let value: string | null = null;
 
   /***** Events *****/
   const forwardEvents = forwardEventsBuilder(get_current_component(), [
@@ -81,6 +88,18 @@
   $: slotProps = { checked };
 </script>
 
+{#if name != null && checked}
+  <Hidden
+    features={HiddenFeatures.Hidden}
+    as="input"
+    type="checkbox"
+    hidden
+    readonly
+    {name}
+    bind:checked
+    bind:value
+  />
+{/if}
 <!-- TODO: I'm sure there's a better way of doing this -->
 {#if switchStore}
   <Render

--- a/src/lib/components/switch/switch.test.ts
+++ b/src/lib/components/switch/switch.test.ts
@@ -3,6 +3,7 @@ import { Switch, SwitchDescription, SwitchGroup, SwitchLabel } from ".";
 import {
   assertActiveElement,
   assertSwitch,
+  getByText,
   getSwitch,
   getSwitchLabel,
   SwitchState,
@@ -322,3 +323,113 @@ describe("Mouse interactions", () => {
     assertSwitch({ state: SwitchState.Off });
   });
 });
+
+describe("`Enter`", () => {
+  it("should submit the form on `Enter`", async () => {    
+    let submitFn = jest.fn();
+    
+    render(svelte`
+      <script>
+        let enabled = false
+      </script>         
+
+      <form on:submit={(event) => {
+        event.preventDefault()
+        submitFn([...new FormData(event.currentTarget).entries()])
+      }}>        
+        <Switch name="notifications" checked={enabled} on:change={(e) => (enabled = e.detail)}>Enable notifications</Switch>
+        <button type="submit">Submit</button>
+      </form>
+    `);
+
+    // Submit the form
+    await click(getByText('Submit'))
+
+    // Verify that the form has been submitted
+    expect(submitFn).lastCalledWith([]) // no data
+
+    // Toggle
+    await click(getSwitch())
+
+    // Submit the form again
+    await click(getByText('Submit'))
+
+    // Verify that the form has been submitted
+    expect(submitFn).lastCalledWith([['notifications', 'on']])
+  });
+});
+
+describe('Form compatibility', () => {
+  it('should be possible to submit a form with an boolean value', async () => {
+    
+    let submitFn = jest.fn();
+    
+    render(svelte`
+      <script>
+        let enabled = false
+      </script>         
+
+      <form on:submit={(event) => {
+        event.preventDefault()
+        submitFn([...new FormData(event.currentTarget).entries()])
+      }}>        
+        <SwitchGroup>
+          <Switch name="notifications" checked={enabled} on:change={(e) => (enabled = e.detail)} />
+          <SwitchLabel>Enable notifications</SwitchLabel>
+        </SwitchGroup>        
+        <button type="submit">Submit</button>
+      </form>
+    `);
+
+    // Submit the form
+    await click(getByText('Submit'))
+
+    // Verify that the form has been submitted
+    expect(submitFn).lastCalledWith([]) // no data
+
+    // Toggle
+    await click(getSwitchLabel())
+
+    // Submit the form again
+    await click(getByText('Submit'))
+
+    // Verify that the form has been submitted
+    expect(submitFn).lastCalledWith([['notifications', 'on']])
+  })
+
+  it('should be possible to submit a form with a provided string value', async () => {
+    let submitFn = jest.fn();
+    
+    render(svelte`
+      <script>
+        let enabled = false
+      </script>         
+
+      <form on:submit={(event) => {
+        event.preventDefault()
+        submitFn([...new FormData(event.currentTarget).entries()])
+      }}>        
+        <SwitchGroup>
+          <Switch name="fruit" checked={enabled} value="apple" on:change={(e) => (enabled = e.detail)} />
+          <SwitchLabel>Apple</SwitchLabel>
+        </SwitchGroup>        
+        <button type="submit">Submit</button>
+      </form>
+    `);
+
+    // Submit the form
+    await click(getByText('Submit'))
+
+    // Verify that the form has been submitted
+    expect(submitFn).lastCalledWith([]) // no data
+
+    // Toggle
+    await click(getSwitchLabel())
+
+    // Submit the form again
+    await click(getByText('Submit'))
+
+    // Verify that the form has been submitted
+    expect(submitFn).lastCalledWith([['fruit', 'apple']])
+  })
+})

--- a/src/lib/hooks/use-controllable.ts
+++ b/src/lib/hooks/use-controllable.ts
@@ -1,0 +1,32 @@
+import { writable, type Writable } from "svelte/store";
+
+export function useControllable<T>(
+  controlledValue: T | undefined,
+  onChange?: (value: T) => void,
+  defaultValue?: T
+) {
+  let internalValue = defaultValue;
+  let isControlled = controlledValue !== undefined;
+
+  //console.log("useControllable", isControlled, controlledValue, internalValue);
+
+  const managedValue: Writable<T> = writable(
+    isControlled ? controlledValue : internalValue
+  );
+
+  return [
+    managedValue,
+    function (value: unknown) {
+      //console.log("useControllable function(value)", value);
+
+      if (isControlled) {
+        managedValue.set(controlledValue as T);
+        return onChange?.(value as T);
+      } else {
+        internalValue = value as T;
+        managedValue.set(internalValue as T);
+        return onChange?.(value as T);
+      }
+    },
+  ] as const;
+}

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -8,3 +8,4 @@ export * from "./components/switch";
 export * from "./components/tabs";
 export * from "./components/transitions";
 export * from "./components/portal";
+export * from "./components/combobox";

--- a/src/lib/internal/Hidden.svelte
+++ b/src/lib/internal/Hidden.svelte
@@ -1,0 +1,39 @@
+<script lang="ts" context="module">
+  export enum Features {
+    // The default, no features.
+    None = 1 << 0,
+
+    // Whether the element should be focusable or not.
+    Focusable = 1 << 1,
+
+    // Whether it should be completely hidden, even to assistive technologies.
+    Hidden = 1 << 2,
+  }
+</script>
+
+<script lang="ts">
+  import type { SupportedAs } from "$lib/internal/elements";
+  import Render from "$lib/utils/Render.svelte";
+
+  export let as: SupportedAs = "div";
+  export let features: Features = Features.None;
+
+  $: propsWeControl = {
+    "aria-hidden":(features & Features.Focusable) === Features.Focusable ? true : undefined,
+    style: `position:fixed;top:1px;left:1px;width:1px;height:0px;padding:0px;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);whitespace:nowrap;border-width:0px;${(features & Features.Hidden) === Features.Hidden && !((features & Features.Focusable) === Features.Focusable) ? 'display:none': ''}`
+  };
+  
+  $: slotProps = {};
+</script>
+
+<Render
+  elementName={$$restProps.name} 
+  style={propsWeControl.style}
+  aria-hidden={propsWeControl["aria-hidden"]}
+  {...{ ...$$restProps }}
+  {as}
+  name={"Hidden"}
+  {slotProps}
+>
+  <slot />
+</Render>

--- a/src/lib/test-utils/accessibility-assertions.ts
+++ b/src/lib/test-utils/accessibility-assertions.ts
@@ -1512,3 +1512,447 @@ export function getByText(text: string): HTMLElement | null {
 
   return null;
 }
+// ---
+
+export function getComboboxLabel(): HTMLElement | null {
+  return document.querySelector('label,[id^="headlessui-combobox-label"]')
+}
+
+export function getComboboxButton(): HTMLElement | null {
+  return document.querySelector('button,[role="button"],[id^="headlessui-combobox-button-"]')
+}
+
+export function getComboboxButtons(): HTMLElement[] {
+  return Array.from(document.querySelectorAll('button,[role="button"]'))
+}
+
+export function getComboboxInput(): HTMLInputElement | null {
+  return document.querySelector('[role="combobox"]')
+}
+
+export function getCombobox(): HTMLElement | null {
+  return document.querySelector('[role="listbox"]')
+}
+
+export function getComboboxInputs(): HTMLElement[] {
+  return Array.from(document.querySelectorAll('[role="combobox"]'))
+}
+
+export function getComboboxes(): HTMLElement[] {
+  return Array.from(document.querySelectorAll('[role="listbox"]'))
+}
+
+export function getComboboxOptions(): HTMLElement[] {
+  return Array.from(document.querySelectorAll('[role="option"]'))
+}
+
+// ---
+
+export enum ComboboxState {
+  /** The combobox is visible to the user. */
+  Visible,
+
+  /** The combobox is **not** visible to the user. It's still in the DOM, but it is hidden. */
+  InvisibleHidden,
+
+  /** The combobox is **not** visible to the user. It's not in the DOM, it is unmounted. */
+  InvisibleUnmounted,
+}
+
+export enum ComboboxMode {
+  /** The combobox is in the `single` mode. */
+  Single,
+
+  /** The combobox is in the `multiple` mode. */
+  Multiple,
+}
+
+export function assertCombobox(
+  options: {
+    attributes?: Record<string, string | null>
+    textContent?: string
+    state: ComboboxState
+    mode?: ComboboxMode
+  },
+  combobox = getComboboxInput()
+) {
+  try {
+    switch (options.state) {
+      case ComboboxState.InvisibleHidden:
+        if (combobox === null) return expect(combobox).not.toBe(null)
+
+        assertHidden(combobox)
+
+        expect(combobox).toHaveAttribute('role', 'combobox')
+
+        if (options.textContent) expect(combobox).toHaveTextContent(options.textContent)
+
+        for (let attributeName in options.attributes) {
+          expect(combobox).toHaveAttribute(attributeName, options.attributes[attributeName])
+        }
+        break
+
+      case ComboboxState.Visible:
+        if (combobox === null) return expect(combobox).not.toBe(null)
+
+        assertVisible(combobox)
+
+        expect(combobox).toHaveAttribute('role', 'combobox')
+
+        if (options.mode && options.mode === ComboboxMode.Multiple) {
+          expect(combobox).toHaveAttribute('aria-multiselectable', 'true')
+        }
+
+        if (options.textContent) expect(combobox).toHaveTextContent(options.textContent)
+
+        for (let attributeName in options.attributes) {
+          expect(combobox).toHaveAttribute(attributeName, options.attributes[attributeName])
+        }
+        break
+
+      case ComboboxState.InvisibleUnmounted:
+        expect(combobox).toBe(null)
+        break
+
+      default:
+        assertNever(options.state)
+    }
+  } catch (err) {
+    if (err instanceof Error) Error.captureStackTrace(err, assertCombobox)
+    throw err
+  }
+}
+
+export function assertComboboxInput(
+  options: {
+    attributes?: Record<string, string | null>
+    state: ComboboxState
+  },
+  input = getComboboxInput()
+) {
+  try {
+    if (input === null) return expect(input).not.toBe(null)
+
+    // Ensure combobox input has these properties
+    expect(input).toHaveAttribute('id')
+
+    switch (options.state) {
+      case ComboboxState.Visible:
+        expect(input).toHaveAttribute('aria-controls')
+        expect(input).toHaveAttribute('aria-expanded', 'true')
+        break
+
+      case ComboboxState.InvisibleHidden:
+        expect(input).toHaveAttribute('aria-controls')
+        if (input.hasAttribute('disabled')) {
+          expect(input).not.toHaveAttribute('aria-expanded')
+        } else {
+          expect(input).toHaveAttribute('aria-expanded', 'false')
+        }
+        break
+
+      case ComboboxState.InvisibleUnmounted:
+        expect(input).not.toHaveAttribute('aria-controls')
+        if (input.hasAttribute('disabled')) {
+          expect(input).not.toHaveAttribute('aria-expanded')
+        } else {
+          expect(input).toHaveAttribute('aria-expanded', 'false')
+        }
+        break
+
+      default:
+        assertNever(options.state)
+    }
+
+    // Ensure combobox input has the following attributes
+    for (let attributeName in options.attributes) {
+      expect(input).toHaveAttribute(attributeName, options.attributes[attributeName])
+    }
+  } catch (err) {
+    if (err instanceof Error) Error.captureStackTrace(err, assertComboboxInput)
+    throw err
+  }
+}
+
+export function assertComboboxList(
+  options: {
+    attributes?: Record<string, string | null>
+    textContent?: string
+    state: ComboboxState
+  },
+  listbox = getCombobox()
+) {
+  try {
+    switch (options.state) {
+      case ComboboxState.InvisibleHidden:
+        if (listbox === null) return expect(listbox).not.toBe(null)
+
+        assertHidden(listbox)
+
+        expect(listbox).toHaveAttribute('aria-labelledby')
+        expect(listbox).toHaveAttribute('role', 'listbox')
+
+        if (options.textContent) expect(listbox).toHaveTextContent(options.textContent)
+
+        for (let attributeName in options.attributes) {
+          expect(listbox).toHaveAttribute(attributeName, options.attributes[attributeName])
+        }
+        break
+
+      case ComboboxState.Visible:
+        if (listbox === null) return expect(listbox).not.toBe(null)
+
+        assertVisible(listbox)
+
+        expect(listbox).toHaveAttribute('aria-labelledby')
+        expect(listbox).toHaveAttribute('role', 'listbox')
+
+        if (options.textContent) expect(listbox).toHaveTextContent(options.textContent)
+
+        for (let attributeName in options.attributes) {
+          expect(listbox).toHaveAttribute(attributeName, options.attributes[attributeName])
+        }
+        break
+
+      case ComboboxState.InvisibleUnmounted:
+        expect(listbox).toBe(null)
+        break
+
+      default:
+        assertNever(options.state)
+    }
+  } catch (err) {
+    if (err instanceof Error) Error.captureStackTrace(err, assertCombobox)
+    throw err
+  }
+}
+
+export function assertComboboxButton(
+  options: {
+    attributes?: Record<string, string | null>
+    textContent?: string
+    state: ComboboxState
+  },
+  button = getComboboxButton()
+) {
+  try {
+    if (button === null) return expect(button).not.toBe(null)
+
+    // Ensure menu button have these properties
+    expect(button).toHaveAttribute('id')
+    expect(button).toHaveAttribute('aria-haspopup')
+
+    switch (options.state) {
+      case ComboboxState.Visible:
+        expect(button).toHaveAttribute('aria-controls')
+        expect(button).toHaveAttribute('aria-expanded', 'true')
+        break
+
+      case ComboboxState.InvisibleHidden:
+        expect(button).toHaveAttribute('aria-controls')
+        if (button.hasAttribute('disabled')) {
+          expect(button).not.toHaveAttribute('aria-expanded')
+        } else {
+          expect(button).toHaveAttribute('aria-expanded', 'false')
+        }
+        break
+
+      case ComboboxState.InvisibleUnmounted:
+        expect(button).not.toHaveAttribute('aria-controls')
+        if (button.hasAttribute('disabled')) {
+          expect(button).not.toHaveAttribute('aria-expanded')
+        } else {
+          expect(button).toHaveAttribute('aria-expanded', 'false')
+        }
+        break
+
+      default:
+        assertNever(options.state)
+    }
+
+    if (options.textContent) {
+      expect(button).toHaveTextContent(options.textContent)
+    }
+
+    // Ensure menu button has the following attributes
+    for (let attributeName in options.attributes) {
+      expect(button).toHaveAttribute(attributeName, options.attributes[attributeName])
+    }
+  } catch (err) {
+    if (err instanceof Error) Error.captureStackTrace(err, assertComboboxButton)
+    throw err
+  }
+}
+
+export function assertComboboxLabel(
+  options: {
+    attributes?: Record<string, string | null>
+    tag?: string
+    textContent?: string
+  },
+  label = getComboboxLabel()
+) {
+  try {
+    if (label === null) return expect(label).not.toBe(null)
+
+    // Ensure menu button have these properties
+    expect(label).toHaveAttribute('id')
+
+    if (options.textContent) {
+      expect(label).toHaveTextContent(options.textContent)
+    }
+
+    if (options.tag) {
+      expect(label.tagName.toLowerCase()).toBe(options.tag)
+    }
+
+    // Ensure menu button has the following attributes
+    for (let attributeName in options.attributes) {
+      expect(label).toHaveAttribute(attributeName, options.attributes[attributeName])
+    }
+  } catch (err) {
+    if (err instanceof Error) Error.captureStackTrace(err, assertComboboxLabel)
+    throw err
+  }
+}
+
+export function assertComboboxButtonLinkedWithCombobox(
+  button = getComboboxButton(),
+  combobox = getCombobox()
+) {
+  try {
+    if (button === null) return expect(button).not.toBe(null)
+    if (combobox === null) return expect(combobox).not.toBe(null)
+
+    // Ensure link between button & combobox is correct
+    expect(button).toHaveAttribute('aria-controls', combobox.getAttribute('id'))
+    expect(combobox).toHaveAttribute('aria-labelledby', button.getAttribute('id'))
+  } catch (err) {
+    if (err instanceof Error) Error.captureStackTrace(err, assertComboboxButtonLinkedWithCombobox)
+    throw err
+  }
+}
+
+export function assertComboboxLabelLinkedWithCombobox(
+  label = getComboboxLabel(),
+  combobox = getComboboxInput()
+) {
+  try {
+    if (label === null) return expect(label).not.toBe(null)
+    if (combobox === null) return expect(combobox).not.toBe(null)
+
+    expect(combobox).toHaveAttribute('aria-labelledby', label.getAttribute('id'))
+  } catch (err) {
+    if (err instanceof Error) Error.captureStackTrace(err, assertComboboxLabelLinkedWithCombobox)
+    throw err
+  }
+}
+
+export function assertComboboxButtonLinkedWithComboboxLabel(
+  button = getComboboxButton(),
+  label = getComboboxLabel()
+) {
+  try {
+    if (button === null) return expect(button).not.toBe(null)
+    if (label === null) return expect(label).not.toBe(null)
+
+    // Ensure link between button & label is correct
+    expect(button).toHaveAttribute('aria-labelledby', `${label.id} ${button.id}`)
+  } catch (err) {
+    if (err instanceof Error)
+      Error.captureStackTrace(err, assertComboboxButtonLinkedWithComboboxLabel)
+    throw err
+  }
+}
+
+export function assertActiveComboboxOption(
+  item: HTMLElement | null,
+  combobox = getComboboxInput()
+) {
+  try {
+    if (combobox === null) return expect(combobox).not.toBe(null)
+    if (item === null) return expect(item).not.toBe(null)
+
+    // Ensure link between combobox & combobox item is correct
+    expect(combobox).toHaveAttribute('aria-activedescendant', item.getAttribute('id'))
+  } catch (err) {
+    if (err instanceof Error) Error.captureStackTrace(err, assertActiveComboboxOption)
+    throw err
+  }
+}
+
+export function assertNotActiveComboboxOption(
+  item: HTMLElement | null,
+  combobox = getComboboxInput()
+) {
+  try {
+    if (combobox === null) return expect(combobox).not.toBe(null)
+    if (item === null) return expect(item).not.toBe(null)
+
+    // Ensure link between combobox & combobox item does not exist
+    expect(combobox).not.toHaveAttribute('aria-activedescendant', item.getAttribute('id'))
+  } catch (err) {
+    if (err instanceof Error) Error.captureStackTrace(err, assertNotActiveComboboxOption)
+    throw err
+  }
+}
+
+export function assertNoActiveComboboxOption(combobox = getComboboxInput()) {
+  try {
+    if (combobox === null) return expect(combobox).not.toBe(null)
+
+    // Ensure we don't have an active combobox
+    expect(combobox).not.toHaveAttribute('aria-activedescendant')
+  } catch (err) {
+    if (err instanceof Error) Error.captureStackTrace(err, assertNoActiveComboboxOption)
+    throw err
+  }
+}
+
+export function assertNoSelectedComboboxOption(items = getComboboxOptions()) {
+  try {
+    for (let item of items) expect(item).toHaveAttribute('aria-selected', 'false')
+  } catch (err) {
+    if (err instanceof Error) Error.captureStackTrace(err, assertNoSelectedComboboxOption)
+    throw err
+  }
+}
+
+export function assertComboboxOption(
+  item: HTMLElement | null,
+  options?: {
+    tag?: string
+    attributes?: Record<string, string | null>
+    selected?: boolean
+  }
+) {
+  try {
+    if (item === null) return expect(item).not.toBe(null)
+
+    // Check that some attributes exists, doesn't really matter what the values are at this point in
+    // time, we just require them.
+    expect(item).toHaveAttribute('id')
+
+    // Check that we have the correct values for certain attributes
+    expect(item).toHaveAttribute('role', 'option')
+    if (!item.getAttribute('aria-disabled')) expect(item).toHaveAttribute('tabindex', '-1')
+
+    // Ensure combobox button has the following attributes
+    if (!options) return
+
+    for (let attributeName in options.attributes) {
+      expect(item).toHaveAttribute(attributeName, options.attributes[attributeName])
+    }
+
+    if (options.tag) {
+      expect(item.tagName.toLowerCase()).toBe(options.tag)
+    }
+
+    if (options.selected != null) {
+      return expect(item).toHaveAttribute('aria-selected', options.selected ? 'true' : 'false')
+    }
+  } catch (err) {
+    if (err instanceof Error) Error.captureStackTrace(err, assertComboboxOption)
+    throw err
+  }
+}

--- a/src/lib/utils/Render.svelte
+++ b/src/lib/utils/Render.svelte
@@ -21,6 +21,9 @@
   export let name: string;
   export let as: TAsProp;
   export let slotProps: TSlotProps;
+  // A workaround for passing name="" to the element since name is already used
+  // Will not be need when <Render> is replaced with <svelte:element>
+  export let elementName:string | null = null;
 
   export let el: HTMLElement | null = null;
   export let use: HTMLActionArray = [];
@@ -64,12 +67,16 @@
     !unmount;
 
   $: propsWeControl = {
+    name:elementName || undefined,
     class: computedClass,
     style:
       `${computedStyle ?? ""}${hidden ? " display: none" : ""}` || undefined,
   };
   $: if (propsWeControl.style === undefined) {
     delete propsWeControl.style;
+  }
+  $: if (propsWeControl.name === undefined) {
+    delete propsWeControl.name;
   }
 </script>
 

--- a/src/lib/utils/focus-management.ts
+++ b/src/lib/utils/focus-management.ts
@@ -163,3 +163,21 @@ export function focusIn(container: HTMLElement | HTMLElement[], focus: Focus) {
 
   return FocusResult.Success;
 }
+
+export function sortByDomNode<T>(
+  nodes: T[],
+  resolveKey: (item: T) => HTMLElement | null = (i) => i as unknown as HTMLElement | null
+): T[] {
+  return nodes.slice().sort((aItem, zItem) => {
+    let a = resolveKey(aItem)
+    let z = resolveKey(zItem)
+
+    if (a === null || z === null) return 0
+
+    let position = a.compareDocumentPosition(z)
+
+    if (position & Node.DOCUMENT_POSITION_FOLLOWING) return -1
+    if (position & Node.DOCUMENT_POSITION_PRECEDING) return 1
+    return 0
+  })
+}

--- a/src/lib/utils/form.ts
+++ b/src/lib/utils/form.ts
@@ -1,0 +1,37 @@
+type Entries = [string, string][];
+
+export function objectToFormEntries(
+  source: Record<string, any> = {},
+  parentKey: string | null = null,
+  entries: Entries = []
+): Entries {
+  for (let [key, value] of Object.entries(source)) {
+    append(entries, composeKey(parentKey, key), value);
+  }
+
+  return entries;
+}
+
+function composeKey(parent: string | null, key: string): string {
+  return parent ? parent + "[" + key + "]" : key;
+}
+
+function append(entries: Entries, key: string, value: any): void {
+  if (Array.isArray(value)) {
+    for (let [subkey, subvalue] of value.entries()) {
+      append(entries, composeKey(key, subkey.toString()), subvalue);
+    }
+  } else if (value instanceof Date) {
+    entries.push([key, value.toISOString()]);
+  } else if (typeof value === "boolean") {
+    entries.push([key, value ? "1" : "0"]);
+  } else if (typeof value === "string") {
+    entries.push([key, value]);
+  } else if (typeof value === "number") {
+    entries.push([key, `${value}`]);
+  } else if (value === null || value === undefined) {
+    entries.push([key, ""]);
+  } else {
+    objectToFormEntries(value, key, entries);
+  }
+}

--- a/src/lib/utils/keyboard.ts
+++ b/src/lib/utils/keyboard.ts
@@ -5,6 +5,7 @@ export enum Keys {
   Enter = "Enter",
   Escape = "Escape",
   Backspace = "Backspace",
+  Delete = 'Delete',
 
   ArrowLeft = "ArrowLeft",
   ArrowUp = "ArrowUp",

--- a/src/routes/docs/_Sidebar.svelte
+++ b/src/routes/docs/_Sidebar.svelte
@@ -12,6 +12,7 @@
   ];
 
   $: components = [
+    { url: `${base}combobox`, text: "Combobox" },
     { url: `${base}dialog`, text: "Dialog" },
     { url: `${base}disclosure`, text: "Disclosure" },
     { url: `${base}listbox`, text: "Listbox" },

--- a/src/routes/docs/combobox.svx
+++ b/src/routes/docs/combobox.svx
@@ -1,0 +1,1111 @@
+# ComboBox
+
+<script>
+  import Preview from "./_Preview.svelte";
+</script>
+
+<Preview url="examples/combobox" code="" class="h-[410px] bg-rose-300"/>
+
+## Basic example
+
+Comboboxes are built using the `Combobox`, `ComboboxInput`, `ComboboxButton`, `ComboboxOptions`, `ComboboxOption` and `ComboboxLabel` components.
+
+The `ComboboxInput` will automatically open/close the `ComboboxOptions` when searching.
+
+You are completely in charge of how you filter the results, whether it be with a fuzzy search library client-side or by making server-side requests to an API. In this example we will keep the logic simple for demo purposes.
+
+```svelte
+<script>
+  import {
+    Combobox,
+    ComboboxInput,
+    ComboboxOptions,
+    ComboboxOption,
+  } from "@rgossiaux/svelte-headlessui";
+
+  const people = [
+    'Durward Reynolds',
+    'Kenton Towne',
+    'Therese Wunsch',
+    'Benedict Kessler',
+    'Katelyn Rohan',
+  ]
+
+  let query = ''
+  let selectedPerson = people[0];
+
+  $:filteredPeople = query === ''
+      ? people
+      : people.filter((person) => {
+          return person.toLowerCase().includes(query.toLowerCase())
+        })
+  
+</script>
+
+<Combobox value={selectedPerson} on:change={(e) => (selectedPerson = e.detail)}>
+  <ComboboxInput on:change={(e) => query = e.detail} />
+  <ComboboxOptions>
+    {#each filteredPeople as person (person)}
+      <ComboboxOption value={person}>
+        {person}
+      </ComboboxOption>
+    {/each}
+  </ComboboxOptions>
+</Combobox>
+
+```
+
+In the previous example we used a list of `string` values as data, but you can also use objects with additional information. The only caveat is that you have to provide a `displayValue` to the input. This is important so that a string based version of your object can be rendered in the `ComboboxInput`.
+
+```svelte
+<script>
+  import {
+    Combobox,
+    ComboboxInput,
+    ComboboxOptions,
+    ComboboxOption,
+  } from "@rgossiaux/svelte-headlessui";
+
+  const people = [
+    { id: 1, name: 'Durward Reynolds', unavailable: false },
+    { id: 2, name: 'Kenton Towne', unavailable: false },
+    { id: 3, name: 'Therese Wunsch', unavailable: false },
+    { id: 4, name: 'Benedict Kessler', unavailable: true },
+    { id: 5, name: 'Katelyn Rohan', unavailable: false },
+  ]
+
+  let query = ''
+  let selectedPerson = people[0];
+
+  $:filteredPeople = query === ''
+      ? people
+      : people.filter((person) => {
+          return person.name.toLowerCase().includes(query.toLowerCase())
+        })
+  
+</script>
+
+<Combobox value={selectedPerson} on:change={(e) => (selectedPerson = e.detail)}>
+  <ComboboxInput on:change={(e) => query = e.detail} displayValue={(person) => person.name} />
+  <ComboboxOptions>
+    {#each filteredPeople as person (person)}
+      <ComboboxOption value={person} disabled={person.unavailable}>
+        {person.name}
+      </ComboboxOption>
+    {/each}
+  </ComboboxOptions>
+</Combobox>
+
+```
+
+## Styling different states
+
+Headless UI keeps track of a lot of state about each component, like which combobox option is currently selected, whether a popover is open or closed, or which item in a combobox is currently active via the keyboard.
+
+But because the components are headless and completely unstyled out of the box, you can't see this information in your UI until you provide the styles you want for each state yourself.
+
+## Using slots
+
+Each component exposes information about its current state via slot props that you can use to conditionally apply different styles or render different content.
+
+For example, the `ComboboxOption` component exposes an `active` state, which tells you if the item is currently focused via the mouse or keyboard.
+
+```svelte
+<script>
+  import {
+    Combobox,
+    ComboboxInput,
+    ComboboxOptions,
+    ComboboxOption,
+  } from "@rgossiaux/svelte-headlessui";
+  import { CheckIcon } from "@rgossiaux/svelte-heroicons/solid";
+
+  const people = [
+    { id: 1, name: 'Durward Reynolds', unavailable: false },
+    { id: 2, name: 'Kenton Towne', unavailable: false },
+    { id: 3, name: 'Therese Wunsch', unavailable: false },
+    { id: 4, name: 'Benedict Kessler', unavailable: true },
+    { id: 5, name: 'Katelyn Rohan', unavailable: false },
+  ]
+
+  let query = ''
+  let selectedPerson = people[0];
+
+  $:filteredPeople = query === ''
+      ? people
+      : people.filter((person) => {
+          return person.name.toLowerCase().includes(query.toLowerCase())
+        })
+  
+</script>
+
+<Combobox value={selectedPerson} on:change={(e) => (selectedPerson = e.detail)}>
+  <ComboboxInput on:change={(e) => query = e.detail} displayValue={(person) => person.name} />
+  <ComboboxOptions>
+    <!-- Use the `active` state to conditionally style the active option. -->
+    <!-- Use the `selected` state to conditionally style the selected option. -->
+    {#each filteredPeople as person (person)}
+      <ComboboxOption 
+        value={person} 
+        disabled={person.unavailable} 
+        let:active 
+        let:selected
+        class={({ active }) => (active ? "bg-blue-500 text-white" : "bg-white text-black")}
+      >
+        {person.name}
+      </ComboboxOption>
+    {/each}
+  </ComboboxOptions>
+</Combobox>
+
+```
+
+## Binding objects as values
+
+Unlike native HTML form controls which only allow you to provide strings as values, Headless UI supports binding complex objects as well.
+
+```svelte
+<script>
+  import {
+    Combobox,
+    ComboboxInput,
+    ComboboxOptions,
+    ComboboxOption,
+  } from "@rgossiaux/svelte-headlessui";
+
+  const people = [
+    { id: 1, name: 'Durward Reynolds', unavailable: false },
+    { id: 2, name: 'Kenton Towne', unavailable: false },
+    { id: 3, name: 'Therese Wunsch', unavailable: false },
+    { id: 4, name: 'Benedict Kessler', unavailable: true },
+    { id: 5, name: 'Katelyn Rohan', unavailable: false },
+  ]
+
+  let query = ''
+  let selectedPerson = people[0];
+
+  $:filteredPeople = query === ''
+      ? people
+      : people.filter((person) => {
+          return person.name.toLowerCase().includes(query.toLowerCase())
+        })
+  
+</script>
+
+<Combobox value={selectedPerson} on:change={(e) => (selectedPerson = e.detail)}>
+  <ComboboxInput on:change={(e) => query = e.detail} displayValue={(person) => person.name} />
+  <ComboboxOptions>
+    {#each filteredPeople as person (person)}
+      <ComboboxOption value={person} disabled={person.unavailable}>
+        {person.name}
+      </ComboboxOption>
+    {/each}
+  </ComboboxOptions>
+</Combobox>
+
+```
+
+When binding objects as values, it's important to make sure that you use the same instance of the object as both the `value` of the `Combobox` as well as the corresponding `ComboboxOption`, otherwise they will fail to be equal and cause the combobox to behave incorrectly.
+
+To make it easier to work with different instances of the same object, you can use the `by` prop to compare the objects by a particular field instead of comparing object identity:
+
+```svelte
+<script>
+  import {
+    Combobox,
+    ComboboxInput,
+    ComboboxOptions,
+    ComboboxOption,
+  } from "@rgossiaux/svelte-headlessui";
+
+  const departments = [
+    { id: 1, name: 'Marketing', contact: 'Durward Reynolds' },
+    { id: 2, name: 'HR', contact: 'Kenton Towne' },
+    { id: 3, name: 'Sales', contact: 'Therese Wunsch' },
+    { id: 4, name: 'Finance', contact: 'Benedict Kessler' },
+    { id: 5, name: 'Customer service', contact: 'Katelyn Rohan' },
+  ]
+
+  let query = ''
+  let selectedDepartment;
+
+  $:filteredDepartments = query === ''
+      ? departments
+      : departments.filter((department) => {
+          return department.name
+            .toLowerCase()
+            .includes(query.toLowerCase())
+        })  
+  
+</script>
+
+<Combobox 
+    value={selectedDepartment} 
+    on:change={(e) => (selectedDepartment = e.detail)}
+    by="id"
+>
+  <ComboboxInput on:change={(e) => query = e.detail} />
+  <ComboboxOptions>
+    {#each filteredDepartments as department (department)}
+      <ComboboxOption value={department}>
+        {department.name}
+      </ComboboxOption>
+    {/each}
+  </ComboboxOptions>
+</Combobox>
+
+```
+
+You can also pass your own comparison function to the `by` prop if you'd like complete control over how objects are compared:
+
+```svelte
+<script>
+  import {
+    Combobox,
+    ComboboxInput,
+    ComboboxOptions,
+    ComboboxOption,
+  } from "@rgossiaux/svelte-headlessui";
+
+  const departments = [
+    { id: 1, name: 'Marketing', contact: 'Durward Reynolds' },
+    { id: 2, name: 'HR', contact: 'Kenton Towne' },
+    { id: 3, name: 'Sales', contact: 'Therese Wunsch' },
+    { id: 4, name: 'Finance', contact: 'Benedict Kessler' },
+    { id: 5, name: 'Customer service', contact: 'Katelyn Rohan' },
+  ]
+
+  let query = ''
+  let selectedDepartment;
+
+  $:filteredDepartments = query === ''
+      ? departments
+      : departments.filter((department) => {
+          return department.name
+            .toLowerCase()
+            .includes(query.toLowerCase())
+        })
+
+  function compareDepartments(a, b) {
+    return a.name.toLowerCase() === b.name.toLowerCase()
+  }
+  
+</script>
+
+<Combobox 
+    value={selectedDepartment} 
+    on:change={(e) => (selectedDepartment = e.detail)}
+    by={compareDepartments}
+>
+  <ComboboxInput on:change={(e) => query = e.detail} />
+  <ComboboxOptions>
+    {#each filteredDepartments as department (department)}
+      <ComboboxOption value={department}>
+        {department.name}
+      </ComboboxOption>
+    {/each}
+  </ComboboxOptions>
+</Combobox>
+
+```
+
+## Selecting multiple values
+
+The Combobox component allows you to select multiple values. You can enable this by providing an array of values instead of a single value.
+
+```svelte
+<script>
+  import {
+    Combobox,
+    ComboboxInput,
+    ComboboxOptions,
+    ComboboxOption,
+  } from "@rgossiaux/svelte-headlessui";
+
+  const people = [
+    { id: 1, name: 'Durward Reynolds' },
+    { id: 2, name: 'Kenton Towne' },
+    { id: 3, name: 'Therese Wunsch' },
+    { id: 4, name: 'Benedict Kessler' },
+    { id: 5, name: 'Katelyn Rohan' },
+  ]
+
+  let selectedPeople = [people[0], people[1]];
+</script>
+
+<Combobox value={selectedPeople} on:change={(e) => (selectedPeople = e.detail)} multiple>
+  {#if selectedPeople.length > 0}
+    <ul>
+      {#each selectedPeople as person (person)}
+        <li>
+          {{ person.name }}
+        </li>
+      {/each}
+    </ul>
+  {/if}
+  <ComboboxInput displayValue={(person) => person.name} />
+  <ComboboxOptions>
+    {#each people as person (person)}
+      <ComboboxOption value={person}>
+        {person.name}
+      </ComboboxOption>
+    {/each}
+  </ComboboxOptions>
+</Combobox>
+
+```
+
+This will keep the combobox open when you are selecting options, and choosing an option will toggle it in place.
+
+Your `on:change` handler will be called with an array containing all selected options any time an option is added or removed.
+
+## Using a custom label
+
+By default the `Combobox` will use the input contents as the label for screenreaders. If you'd like more control over what is announced to assistive technologies, use the `ComboboxLabel` component.
+
+```svelte
+<script>
+  import {
+    Combobox,
+    ComboboxLabel
+    ComboboxInput,
+    ComboboxOptions,
+    ComboboxOption,
+  } from "@rgossiaux/svelte-headlessui";
+
+  const people = [
+    { id: 1, name: 'Durward Reynolds' },
+    { id: 2, name: 'Kenton Towne' },
+    { id: 3, name: 'Therese Wunsch' },
+    { id: 4, name: 'Benedict Kessler' },
+    { id: 5, name: 'Katelyn Rohan' },
+  ]
+
+  let query = ''
+  let selectedPerson = people[0];
+
+  $:filteredPeople = query === ''
+      ? people
+      : people.filter((person) => {
+          return person.name.toLowerCase().includes(query.toLowerCase())
+        })
+  
+</script>
+
+<Combobox value={selectedPerson} on:change={(e) => (selectedPerson = e.detail)}>
+  <ComboboxLabel>Assignee:</ComboboxLabel>
+  <ComboboxInput on:change={(e) => query = e.detail} displayValue={(person) => person.name} />
+  <ComboboxOptions>
+    {#each filteredPeople as person (person)}
+      <ComboboxOption value={person}>
+        {person.name}
+      </ComboboxOption>
+    {/each}
+  </ComboboxOptions>
+</Combobox>
+
+```
+
+## Using with HTML forms
+
+If you add the `name` prop to your combobox, hidden `input` elements will be rendered and kept in sync with your selected value.
+
+```svelte
+<script>
+  import {
+    Combobox,
+    ComboboxInput,
+    ComboboxOptions,
+    ComboboxOption,
+  } from "@rgossiaux/svelte-headlessui";
+
+  const people = [
+    { id: 1, name: 'Durward Reynolds' },
+    { id: 2, name: 'Kenton Towne' },
+    { id: 3, name: 'Therese Wunsch' },
+    { id: 4, name: 'Benedict Kessler' },
+    { id: 5, name: 'Katelyn Rohan' },
+  ]
+
+  let query = ''
+  let selectedPerson = people[0];
+
+  $:filteredPeople = query === ''
+      ? people
+      : people.filter((person) => {
+          return person.name.toLowerCase().includes(query.toLowerCase())
+        })
+  
+</script>
+
+<form action="/projects/1/assignee" method="post">
+  <Combobox name="assignee" value={selectedPerson} on:change={(e) => (selectedPerson = e.detail)}>    
+    <ComboboxInput on:change={(e) => query = e.detail} displayValue={(person) => person.name} />
+    <ComboboxOptions>
+      {#each filteredPeople as person (person)}
+        <ComboboxOption value={person}>
+          {person.name}
+        </ComboboxOption>
+      {/each}
+    </ComboboxOptions>
+  </Combobox>
+  <button>Submit</button>
+</form>
+```
+
+This lets you use a combobox inside a native HTML `<form>` and make traditional form submissions as if your combobox was a native HTML form control.
+
+Basic values like strings will be rendered as a single hidden input containing that value, but complex values like objects will be encoded into multiple inputs using a square bracket notation for the names:
+
+```svelte
+<input type="hidden" name="assignee[id]" value="1" />
+<input type="hidden" name="assignee[name]" value="Durward Reynolds" />
+```
+
+## Using as an uncontrolled component
+
+If you provide a `defaultValue` prop to the `Combobox` instead of a `value`, Headless UI will track its state internally for you, allowing you to use it as an uncontrolled component.
+
+```svelte
+<script>
+  import {
+    Combobox,
+    ComboboxInput,
+    ComboboxOptions,
+    ComboboxOption,
+  } from "@rgossiaux/svelte-headlessui";
+
+  const people = [
+    { id: 1, name: 'Durward Reynolds' },
+    { id: 2, name: 'Kenton Towne' },
+    { id: 3, name: 'Therese Wunsch' },
+    { id: 4, name: 'Benedict Kessler' },
+    { id: 5, name: 'Katelyn Rohan' },
+  ]
+
+  let query = ''
+  
+  $:filteredPeople = query === ''
+      ? people
+      : people.filter((person) => {
+          return person.name.toLowerCase().includes(query.toLowerCase())
+        })
+  
+</script>
+
+<form action="/projects/1/assignee" method="post">
+  <Combobox name="assignee" defaultValue={people[0]}>    
+    <ComboboxInput on:change={(e) => query = e.detail} displayValue={(person) => person.name} />
+    <ComboboxOptions>
+      {#each filteredPeople as person (person)}
+        <ComboboxOption value={person}>
+          {person.name}
+        </ComboboxOption>
+      {/each}
+    </ComboboxOptions>
+  </Combobox>
+  <button>Submit</button>
+</form>
+```
+
+This can simplify your code when using the combobox with HTML forms or with form APIs that collect their state using FormData instead of tracking it using React state.
+
+Any `on:change` prop you provide will still be called when the component's value changes in case you need to run any side effects, but you won't need to use it to track the component's state yourself.
+
+## Allowing custom values
+
+You can allow users to enter their own value that doesn't exist in the list by including a dynamic `ComboboxOption` based on the `query` value.
+
+```svelte
+<script>
+  import {
+    Combobox,
+    ComboboxLabel
+    ComboboxInput,
+    ComboboxOptions,
+    ComboboxOption,
+  } from "@rgossiaux/svelte-headlessui";
+
+  const people = [
+    { id: 1, name: 'Durward Reynolds' },
+    { id: 2, name: 'Kenton Towne' },
+    { id: 3, name: 'Therese Wunsch' },
+    { id: 4, name: 'Benedict Kessler' },
+    { id: 5, name: 'Katelyn Rohan' },
+  ]
+
+  let query = ''
+  let selectedPerson = people[0];
+
+  $:filteredPeople = query === ''
+      ? people
+      : people.filter((person) => {
+          return person.name.toLowerCase().includes(query.toLowerCase())
+        })
+
+  $:queryPerson = query === '' ? null : { id: null, name: query.value }
+  
+</script>
+
+<Combobox value={selectedPerson} on:change={(e) => (selectedPerson = e.detail)}>  
+  <ComboboxInput on:change={(e) => query = e.detail} displayValue={(person) => person.name} />
+  <ComboboxOptions>
+    {#if queryPerson}
+      <ComboboxOption value={queryPerson}>
+          Create "{query}"
+      </ComboboxOption>
+    {/if}
+    {#each filteredPeople as person (person)}
+      <ComboboxOption value={person}>
+        {person.name}
+      </ComboboxOption>
+    {/each}
+  </ComboboxOptions>
+</Combobox>
+
+```
+
+## Rendering the active option on the side
+
+Depending on what you're building it can sometimes make sense to render additional information about the active option outside of the `<ComboboxOptions>`. For example, a preview of the active option within the context of a command palette. In these situations you can read the `activeOption` slot prop argument to access this information.
+
+```svelte
+<script>
+  import {
+    Combobox,
+    ComboboxLabel
+    ComboboxInput,
+    ComboboxOptions,
+    ComboboxOption,
+  } from "@rgossiaux/svelte-headlessui";
+
+  const people = [
+    { id: 1, name: 'Durward Reynolds' },
+    { id: 2, name: 'Kenton Towne' },
+    { id: 3, name: 'Therese Wunsch' },
+    { id: 4, name: 'Benedict Kessler' },
+    { id: 5, name: 'Katelyn Rohan' },
+  ]
+
+  let query = ''
+  let selectedPerson = people[0];
+
+  $:filteredPeople = query === ''
+      ? people
+      : people.filter((person) => {
+          return person.name.toLowerCase().includes(query.toLowerCase())
+        })
+
+  $:queryPerson = query === '' ? null : { id: null, name: query.value }
+  
+</script>
+
+<Combobox value={selectedPerson} on:change={(e) => (selectedPerson = e.detail)} let:activeOption>  
+  <ComboboxInput on:change={(e) => query = e.detail} displayValue={(person) => person.name} />
+  <ComboboxOptions>    
+    {#each filteredPeople as person (person)}
+      <ComboboxOption value={person}>
+        {person.name}
+      </ComboboxOption>
+    {/each}
+  </ComboboxOptions>
+
+  {#if activeOption}
+    <div>
+        The current active user is: {{ activeOption.name }}
+    </div>
+  {/if}
+</Combobox>
+```
+
+The `activeOption` will be the `value` of the current active `ComboboxOption`.
+
+## Showing/hiding the combobox
+
+By default, your `ComboboxOptions` instance will be shown/hidden automatically based on the internal `open` state tracked within the `Combobox` component itself.
+
+```svelte
+<script>
+  import {
+    Combobox,
+    ComboboxLabel
+    ComboboxInput,
+    ComboboxOptions,
+    ComboboxOption,
+  } from "@rgossiaux/svelte-headlessui";
+
+  const people = [
+    { id: 1, name: 'Durward Reynolds' },
+    { id: 2, name: 'Kenton Towne' },
+    { id: 3, name: 'Therese Wunsch' },
+    { id: 4, name: 'Benedict Kessler' },
+    { id: 5, name: 'Katelyn Rohan' },
+  ]
+
+  let query = ''
+  let selectedPerson = people[0];
+
+  $:filteredPeople = query === ''
+      ? people
+      : people.filter((person) => {
+          return person.name.toLowerCase().includes(query.toLowerCase())
+        })
+
+</script>
+
+<Combobox value={selectedPerson} on:change={(e) => (selectedPerson = e.detail)}>  
+  <ComboboxInput on:change={(e) => query = e.detail} displayValue={(person) => person.name} />
+
+  <!--
+    By default, the `ComboboxOptions` will automatically show/hide when
+    typing in the `ComboboxInput`, or when pressing the `ComboboxButton`.
+  -->
+  <ComboboxOptions>    
+    {#each filteredPeople as person (person)}
+      <ComboboxOption value={person}>
+        {person.name}
+      </ComboboxOption>
+    {/each}
+  </ComboboxOptions>
+</Combobox>
+```
+
+If you'd rather handle this yourself (perhaps because you need to add an extra wrapper element for one reason or another), you can add a `static` prop to the `ComboboxOptions` instance to tell it to always render, and inspect the `open` slot prop provided by the `Combobox` to control which element is shown/hidden yourself.
+
+```svelte
+<script>
+  import {
+    Combobox,
+    ComboboxLabel
+    ComboboxInput,
+    ComboboxOptions,
+    ComboboxOption,
+  } from "@rgossiaux/svelte-headlessui";
+
+  const people = [
+    { id: 1, name: 'Durward Reynolds' },
+    { id: 2, name: 'Kenton Towne' },
+    { id: 3, name: 'Therese Wunsch' },
+    { id: 4, name: 'Benedict Kessler' },
+    { id: 5, name: 'Katelyn Rohan' },
+  ]
+
+  let query = ''
+  let selectedPerson = people[0];
+
+  $:filteredPeople = query === ''
+      ? people
+      : people.filter((person) => {
+          return person.name.toLowerCase().includes(query.toLowerCase())
+        })
+
+</script>
+
+<Combobox value={selectedPerson} on:change={(e) => (selectedPerson = e.detail)} let:open>  
+  <ComboboxInput on:change={(e) => query = e.detail} displayValue={(person) => person.name} />
+
+  {#if open}
+    <!--
+      Using the `static` prop, the `ComboboxOptions` are always
+      rendered and the `open` state is ignored.
+    -->
+    <ComboboxOptions static>    
+      {#each filteredPeople as person (person)}
+        <ComboboxOption value={person}>
+          {person.name}
+        </ComboboxOption>
+      {/each}
+    </ComboboxOptions>
+  {/if}
+</Combobox>
+```
+
+## Disabling an option
+
+Use the `disabled` prop to disable a `ComboboxOption`. This will make it unselectable via mouse and keyboard, and it will be skipped when pressing the up/down arrows.
+
+```svelte
+<script>
+  import {
+    Combobox,
+    ComboboxLabel
+    ComboboxInput,
+    ComboboxOptions,
+    ComboboxOption,
+  } from "@rgossiaux/svelte-headlessui";
+
+  const people = [
+    { id: 1, name: 'Durward Reynolds', unavailable: true },
+    { id: 2, name: 'Kenton Towne', unavailable: false },
+    { id: 3, name: 'Therese Wunsch', unavailable: false },
+    { id: 4, name: 'Benedict Kessler', unavailable: true },
+    { id: 5, name: 'Katelyn Rohan', unavailable: false },
+  ]
+
+  let query = ''
+  let selectedPerson = people[0];
+
+  $:filteredPeople = query === ''
+      ? people
+      : people.filter((person) => {
+          return person.name.toLowerCase().includes(query.toLowerCase())
+        })
+
+</script>
+
+<Combobox value={selectedPerson} on:change={(e) => (selectedPerson = e.detail)}>  
+  <ComboboxInput on:change={(e) => query = e.detail} displayValue={(person) => person.name} />
+  
+  <ComboboxOptions>    
+    {#each filteredPeople as person (person)}
+      <ComboboxOption value={person} disabled={person.unavailable}>
+        <span class:opacity-75={person.unavailable}>
+          {{ person.name }}
+        </span>
+      </ComboboxOption>
+    {/each}
+  </ComboboxOptions>
+</Combobox>
+```
+
+## Allowing empty values
+
+By default, once you've selected a value in a combobox there is no way to clear the combobox back to an empty value — when you clear the input and tab away, the value returns to the previously selected value.
+
+If you want to support empty values in your combobox, use the `nullable` prop.
+
+```svelte
+<script>
+  import {
+    Combobox,
+    ComboboxLabel
+    ComboboxInput,
+    ComboboxOptions,
+    ComboboxOption,
+  } from "@rgossiaux/svelte-headlessui";
+
+  const people = [
+    { id: 1, name: 'Durward Reynolds', unavailable: true },
+    { id: 2, name: 'Kenton Towne', unavailable: false },
+    { id: 3, name: 'Therese Wunsch', unavailable: false },
+    { id: 4, name: 'Benedict Kessler', unavailable: true },
+    { id: 5, name: 'Katelyn Rohan', unavailable: false },
+  ]
+
+  let query = ''
+  let selectedPerson = people[0];
+
+  $:filteredPeople = query === ''
+      ? people
+      : people.filter((person) => {
+          return person.name.toLowerCase().includes(query.toLowerCase())
+        })
+
+</script>
+
+<Combobox value={selectedPerson} on:change={(e) => (selectedPerson = e.detail)} nullable>  
+  <ComboboxInput on:change={(e) => query = e.detail} displayValue={(person) => person?.name} />
+  
+  <ComboboxOptions>    
+    {#each filteredPeople as person (person)}
+      <ComboboxOption value={person} disabled={person.unavailable}>
+        <span class:opacity-75={person.unavailable}>
+          {{ person.name }}
+        </span>
+      </ComboboxOption>
+    {/each}
+  </ComboboxOptions>
+</Combobox>
+```
+
+When the `nullable` prop is used, clearing the input and navigating away from the element will update your `value` binding and invoke your `displayValue` callback with `null`.
+
+This prop doesn't do anything when allowing multiple values because options are toggled on and off, resulting in an empty array (rather than null) if nothing is selected.
+
+## Transitions
+
+To animate the opening and closing of the Combobox, you can use [this library's Transition component](/docs/transition) or Svelte's built-in transition engine. See that page for a comparison.
+
+### Using the `Transition` component
+To animate the opening/closing of the combobox panel, use the provided `Transition` component. All you need to do is wrap the `ComboboxOptions` in a `<Transition>`, and the transition will be applied automatically.
+
+```svelte
+<script>
+  import {
+    Combobox,
+    ComboboxLabel
+    ComboboxInput,
+    ComboboxOptions,
+    ComboboxOption,
+    Transition,
+  } from "@rgossiaux/svelte-headlessui";
+
+  const people = [
+    { id: 1, name: 'Durward Reynolds' },
+    { id: 2, name: 'Kenton Towne' },
+    { id: 3, name: 'Therese Wunsch' },
+    { id: 4, name: 'Benedict Kessler' },
+    { id: 5, name: 'Katelyn Rohan' },
+  ]
+
+  let query = ''
+  let selectedPerson = people[0];
+
+  $:filteredPeople = query === ''
+      ? people
+      : people.filter((person) => {
+          return person.name.toLowerCase().includes(query.toLowerCase())
+        })  
+  
+</script>
+
+<Combobox value={selectedPerson} on:change={(e) => (selectedPerson = e.detail)}>  
+  <ComboboxInput on:change={(e) => query = e.detail} displayValue={(person) => person.name} />
+  <!-- Example using Tailwind CSS transition classes -->
+  <Transition
+    enter="transition duration-100 ease-out"
+    enterFrom="transform scale-95 opacity-0"
+    enterTo="transform scale-100 opacity-100"
+    leave="transition duration-75 ease-out"
+    leaveFrom="transform scale-100 opacity-100"
+    leaveTo="transform scale-95 opacity-0"
+  >
+    <ComboboxOptions>    
+      {#each filteredPeople as person (person)}
+        <ComboboxOption value={person}>
+          {person.name}
+        </ComboboxOption>
+      {/each}
+    </ComboboxOptions>
+  </Transition>
+</Combobox>
+
+```
+
+The components in this library communicate with each other, so the Transition will be managed automatically when the Combobox is opened/closed.
+
+### Using Svelte transitions
+
+```svelte
+<script>
+  import {
+    Combobox,
+    ComboboxLabel
+    ComboboxInput,
+    ComboboxOptions,
+    ComboboxOption,    
+  } from "@rgossiaux/svelte-headlessui";
+  import { fade } from "svelte/transition";
+
+  const people = [
+    { id: 1, name: 'Durward Reynolds' },
+    { id: 2, name: 'Kenton Towne' },
+    { id: 3, name: 'Therese Wunsch' },
+    { id: 4, name: 'Benedict Kessler' },
+    { id: 5, name: 'Katelyn Rohan' },
+  ]
+
+  let query = ''
+  let selectedPerson = people[0];
+
+  $:filteredPeople = query === ''
+      ? people
+      : people.filter((person) => {
+          return person.name.toLowerCase().includes(query.toLowerCase())
+        })  
+  
+</script>
+
+<Combobox value={selectedPerson} on:change={(e) => (selectedPerson = e.detail)} let:open>  
+  <ComboboxInput on:change={(e) => query = e.detail} displayValue={(person) => person.name} />
+  {#if open}
+    <div transition:fade>
+    <!-- When controlling the transition manually, make sure to use `static` -->
+      <ComboboxOptions static>    
+        {#each filteredPeople as person (person)}
+          <ComboboxOption value={person}>
+            {person.name}
+          </ComboboxOption>
+        {/each}
+      </ComboboxOptions>
+    </div>
+  {/if}
+</Combobox>
+
+```
+
+Make sure to use the `static` prop, or else the exit transitions won't work correctly.
+
+## Rendering a different element for a component
+
+By default, the `Combobox` and its subcomponents each render a default element that is sensible for that component.
+
+For example, `ComboboxLabel` renders a `label` by default, `ComboboxInput` renders an `input`, `ComboboxButton` renders a `button`, `ComboboxOptions` renders a `ul`, and `ComboboxOption` renders a `li`. By contrast, `Combobox` does not render an element, and instead renders its children directly.
+
+This is easy to change using the `as` prop, which exists on every component.
+
+```svelte
+<script>
+  import {
+    Combobox,
+    ComboboxLabel
+    ComboboxInput,
+    ComboboxOptions,
+    ComboboxOption,
+  } from "@rgossiaux/svelte-headlessui";
+
+  const people = [
+    { id: 1, name: 'Durward Reynolds' },
+    { id: 2, name: 'Kenton Towne' },
+    { id: 3, name: 'Therese Wunsch' },
+    { id: 4, name: 'Benedict Kessler' },
+    { id: 5, name: 'Katelyn Rohan' },
+  ]
+
+  let query = ''
+  let selectedPerson = people[0];
+
+  $:filteredPeople = query === ''
+      ? people
+      : people.filter((person) => {
+          return person.name.toLowerCase().includes(query.toLowerCase())
+        })
+  
+</script>
+
+<Combobox value={selectedPerson} on:change={(e) => (selectedPerson = e.detail)} as="div">  
+  <ComboboxInput on:change={(e) => query = e.detail} displayValue={(person) => person.name} />
+
+  <!-- Render a `div` instead of a `ul` -->
+  <ComboboxOptions as="div">    
+    {#each filteredPeople as person (person)}
+      <!-- Render a `span` instead of a `li` -->
+      <ComboboxOption value={person} as="span">
+        {person.name}
+      </ComboboxOption>
+    {/each}
+  </ComboboxOptions>  
+</Combobox>
+```
+
+## Accessibility notes
+
+### Focus management
+
+When a `Combobox` is toggled open, the `ComboboxInput` stays focused.
+
+The `ComboboxButton` is ignored for the default tab flow, this means that pressing `Tab` in the `ComboboxInput` will skip passed the `ComboboxButton`.
+
+### Mouse interaction
+
+Clicking a `ComboboxButton` toggles the options list open and closed. Clicking anywhere outside of the options list will close the combobox.
+
+### Keyboard interaction
+
+| Command                                                                               | Description                                                       |
+| ------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| `<ArrowUp>` / `<ArrowDown>` when ComboboxInput is focused                             | Opens combobox and focuses the selected item                      |
+| `<Enter>` / `<Space>` / `<ArrowUp>` / `<ArrowDown>` when `ComboboxButton ` is focused | Opens combobox, focuses the input and selects the selected item   |
+| `<Esc>` when combobox is open                                                         | Closes combobox and restores the selected item in the input field |                               |
+| `<ArrowDown>` / `<ArrowUp>` when combobox is open                                     | Focuses previous/next non-disabled item                           |
+| `<Home>` / `<End>` when combobox is open                                              | Focuses first/last non-disabled item                              |
+| `<Enter>` when combobox is open                                                       | Selects the current item                                          |
+| `<Tab>` when combobox is open                                                         | Selects the current active item and closes the combobox           |
+| `<A-Za-z>` when combobox is open                                                      | Calls the onChange which allows you to filter the list            |
+
+### Other
+
+All relevant ARIA attributes are automatically managed.
+
+## Component API
+
+### Combobox
+
+The main Combobox component.
+
+| Prop            | Default | Type                                  | Description                                                                                                                                 |
+| --------------- | ------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `as`            | `div`   | `string`                              | The element the `Combobox` should render as                                                                                                 |
+| `value`         | --      | `T`                                   | The selected value                                                                                                                          |
+| `defaultValue`  | --      | `T`                                   | The default value when using as an uncontrolled component.                                                                                  |
+| `by`            | --      | `keyof T` \| `((a: T, z: T) => boolean)` |  Use this to compare objects by a particular field, or pass your own comparison function for complete control over how objects are compared.|                                              |
+| `disabled`      | `false` | `boolean`                             | Use this to disable the entire combobox component & related children.                                                                       |
+| `name`          | --      | `string`                              | The name used when using this component inside a form.                                                                                      |
+| `nullable`      | --      | `Boolean`                             | Whether you can clear the combobox or not.                                                                                                  |
+| `multiple`      | `false` | `Boolean`                             | Whether multiple options can be selected or not.                                                                                            |
+
+
+| Slot prop  | Type      | Description                             |
+| ---------- | --------- | --------------------------------------- |
+| `value` | `T` | The selected value.                              |
+| `open` | `Boolean` | Whether or not the combobox is open.        |
+| `disabled` | `boolean` | Whether or not the Combobox is disabled |
+| `activeIndex` | `Number` \| `null` | The index of the active option or null if none is active. |
+| `activeOption` | `T` \| `null` | The active option or null if none is active. |
+
+
+This component also dispatches a custom event, which is listened to using the Svelte `on:` directive:
+
+| Event name | Type of event `.detail` | Description                                                                                                   |
+| ---------- | ----------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `change`   | `T`                     | Dispatched when a `ComboboxOption` is selected; the event `detail` contains the `value` of the selected option |
+
+
+### ComboboxInput
+
+The Combobox's input.
+
+| Prop            | Default | Type                                  | Description                                                                                                                                 |
+| --------------- | ------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `as`            | `input` | `string`                              | The element or component the ComboboxInput should render as.                                                                                                |
+| `displayValue`  | --      | `(item: T) => string`                 | The string representation of your value.                                                                                                                        |
+| `defaultValue`  | --      | `T`                                   | The default value when using as an uncontrolled component.                                                                                  |
+
+| Slot prop  | Type      | Description                           |
+| ---------- | --------- | --------------------------------------- |
+| `open`     | `Boolean` | Whether or not the combobox is open.    |
+| `disabled` | `boolean` | Whether or not the Combobox is disabled |
+
+### ComboboxLabel
+
+A label that can be used for more control over the text your Combobox will announce to screenreaders. Its `id` attribute will be automatically generated and linked to the root `Combobox` component via the `aria-labelledby` attribute.
+
+| Prop            | Default | Type                                  | Description                                                                                                                                 |
+| --------------- | ------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `as`            | `label` | `string`                              | The element or component the `ComboboxLabel` should render as.                                                                                                |
+
+| Render prop  | Type      | Description                           |
+| ---------- | --------- | --------------------------------------- |
+| `open`     | `Boolean` | Whether or not the Combobox is open.    |
+| `disabled` | `boolean` | Whether or not the Combobox is disabled |
+
+### ComboboxOptions
+
+The component that directly wraps the list of options in your custom Combobox.
+
+| Prop            | Default | Type                                  | Description                                                                                           |
+| --------------- | ------- | ------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `as`            | `ul`    | `string`                              | The element or component the `ComboboxOptions` should render as.                                      |
+| `static`        | `false` | `Boolean`                             | Whether the element should ignore the internally managed open/closed state.                           |
+| `unmount`       | `true`  | `Boolean`                             | Whether the element should be unmounted or hidden based on the open/closed state.                     |
+| `hold`          | `false` | `Boolean`                             | Whether or not the active option should stay active even when the mouse leaves the active option.     |
+
+| Render prop  | Type      | Description                           |
+| ---------- | --------- | --------------------------------------- |
+| `open`     | `Boolean` | Whether or not the Combobox is open.    |
+
+### ComboboxOption
+
+Used to wrap each item within your Combobox.
+
+| Prop            | Default | Type                                  | Description                                                                          |
+| --------------- | ------- | ------------------------------------- | ------------------------------------------------------------------------------------ |
+| `value`         | `T`     | `Boolean`                             | The option value.                                                                    |
+| `as`            | `li`    | `string`                              | The element or component the `ComboboxOption` should render as.                      |
+| `disabled`      | `false` | `Boolean`                             | Whether or not the option should be disabled for keyboard navigation and ARIA purposes.    |
+
+| Render prop  | Type      | Description                           |
+| ---------- | --------- | --------------------------------------- |
+| `active`     | `Boolean` | Whether or not the option is the active/focused option.    |
+| `selected`     | `Boolean` | Whether or not the option is the selected option.    |
+| `disabled`     | `Boolean` | Whether or not the option is the disabled for keyboard navigation and ARIA purposes.    |

--- a/src/routes/docs/examples/combobox.svelte
+++ b/src/routes/docs/examples/combobox.svelte
@@ -1,0 +1,106 @@
+<script lang="ts">
+  import {
+    Combobox,
+    ComboboxButton,
+    ComboboxInput, ComboboxOption, ComboboxOptions, Transition
+  } from "$lib";
+
+  import { CheckIcon, SelectorIcon } from "@rgossiaux/svelte-heroicons/solid";
+
+  const people = [
+    { id: 1, name: "Wade Cooper" },
+    { id: 2, name: "Arlene Mccoy" },
+    { id: 3, name: "Devon Webb" },
+    { id: 4, name: "Tom Cook" },
+    { id: 5, name: "Tanya Fox" },
+    { id: 6, name: "Hellen Schmidt" },
+  ];
+
+  let selected: any = people[0]
+  let query = "";
+  
+  $: filteredPeople =
+    query === ""
+      ? people
+      : people.filter((person) =>
+          person.name
+            .toLowerCase()
+            .replace(/\s+/g, "")
+            .includes(query.toLowerCase().replace(/\s+/g, ""))
+        );
+
+  function displayByName(person: typeof people[number]) : string {
+    return person?.name;
+  }
+
+  function handleInputChange(e: Event) {
+    const event = e as any
+    query = event.detail;
+  }
+</script>
+
+<div class="fixed top-16 w-72">  
+  <Combobox value={selected} on:change={(e) => (selected = e.detail)}>
+    <div class="relative mt-1">
+      <div
+        class="relative w-full cursor-default overflow-hidden rounded-lg bg-white text-left shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75 focus-visible:ring-offset-2 focus-visible:ring-offset-teal-300 sm:text-sm"
+      >
+        <ComboboxInput
+          class="w-full border-none py-2 pl-3 pr-10 text-sm leading-5 text-gray-900 focus:ring-0"
+          displayValue={displayByName}
+          on:change={handleInputChange}
+        />
+        <ComboboxButton
+          class="absolute inset-y-0 right-0 flex items-center pr-2"
+        >
+          <SelectorIcon class="h-5 w-5 text-gray-400" aria-hidden="true" />
+        </ComboboxButton>
+      </div>
+      <Transition
+        leave="transition ease-in duration-100"
+        leaveFrom="opacity-100"
+        leaveTo="opacity-0"
+        on:afterLeave={(e) => (query = "")}
+      >
+        <ComboboxOptions
+          class="absolute mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm"
+        >
+          {#if filteredPeople.length === 0 && query !== ""}
+            <div
+              class="relative cursor-default select-none py-2 px-4 text-gray-700"
+            >
+              Nothing found.
+            </div>
+          {/if}
+
+          {#each filteredPeople as person, idx (person)}
+            <ComboboxOption value={person} let:selected let:active>
+              <li
+                class={`relative cursor-default select-none py-2 pl-10 pr-4 ${
+                  active ? "bg-teal-600 text-white" : "text-gray-900"
+                }`}
+              >
+                <span
+                  class={`block truncate ${
+                    selected ? "font-medium" : "font-normal"
+                  }`}
+                >
+                  {person.name}
+                </span>
+                {#if selected}
+                  <span
+                    class={`absolute inset-y-0 left-0 flex items-center pl-3 ${
+                      active ? "text-white" : "text-teal-600"
+                    }`}
+                  >
+                    <CheckIcon class="h-5 w-5" aria-hidden="true" />
+                  </span>
+                {/if}
+              </li>
+            </ComboboxOption>
+          {/each}
+        </ComboboxOptions>
+      </Transition>
+    </div>
+  </Combobox>
+</div>

--- a/src/routes/docs/listbox.svx
+++ b/src/routes/docs/listbox.svx
@@ -259,6 +259,51 @@ Use the `disabled` prop to disable a `ListboxOption`. This will make it unselect
 </Listbox>
 ```
 
+## Using with HTML forms
+
+If you add the `name` prop to your listbox, hidden `input` elements will be rendered and kept in sync with your selected value.
+
+```svelte
+<script>
+  import {
+    Listbox,
+    ListboxButton,
+    ListboxOptions,
+    ListboxOption,
+  } from "@rgossiaux/svelte-headlessui";
+
+  const people = [
+    { id: 1, name: "Durward Reynolds", unavailable: false },
+    { id: 2, name: "Kenton Towne", unavailable: false },
+    { id: 3, name: "Therese Wunsch", unavailable: false },
+    { id: 4, name: "Benedict Kessler", unavailable: true },
+    { id: 5, name: "Katelyn Rohan", unavailable: false },
+  ];
+
+  let selectedPerson = people[0];
+</script>
+
+<Listbox value={selectedPerson} on:change={(e) => (selectedPerson = e.detail)} name="assignee">
+  <ListboxButton>{selectedPerson.name}</ListboxButton>
+  <ListboxOptions>
+    {#each people as person (person.id)}
+      <ListboxOption value={person} disabled={person.unavailable}>
+        {person.name}
+      </ListboxOption>
+    {/each}
+  </ListboxOptions>
+</Listbox>
+```
+
+This lets you use a listbox inside a native HTML `<form>` and make traditional form submissions as if your listbox was a native HTML form control.
+
+Basic values like strings will be rendered as a single hidden input containing that value, but complex values like objects will be encoded into multiple inputs using a square bracket notation for the names:
+
+```svelte
+<input type="hidden" name="assignee[id]" value="1" />
+<input type="hidden" name="assignee[name]" value="Durward Reynolds" />
+```
+
 ## Transitions
 
 To animate the opening and closing of the listbox, you can use [this library's Transition component](/docs/transition) or Svelte's built-in transition engine. See that page for a comparison.
@@ -490,6 +535,7 @@ The main listbox component.
 | `disabled`   | `false` | `boolean` | Whether the entire `Listbox` and its children should be disabled                   |
 | `horizontal` | `false` | `boolean` | Whether the entire `Listbox` should be oriented horizontally instead of vertically |
 | `value`      | --      | `T`       | The selected value                                                                 |
+| `name`       | --      | `string`  | The name used when using this component inside a form.                             |
 
 | Slot prop  | Type      | Description                            |
 | ---------- | --------- | -------------------------------------- |

--- a/src/routes/docs/radio-group.svx
+++ b/src/routes/docs/radio-group.svx
@@ -153,6 +153,42 @@ By default, `RadioGroupLabel` renders a `<label>` element and `RadioGroupDescrip
 </style>
 ```
 
+## Using with HTML forms
+
+If you add the `name` prop to your listbox, hidden `input` elements will be rendered and kept in sync with your selected value.
+
+```svelte
+<script>
+  import {
+    RadioGroup,
+    RadioGroupLabel,
+    RadioGroupOption,
+    RadioGroupDescription,
+  } from "@rgossiaux/svelte-headlessui";
+
+  const plans = ['startup', 'business', 'enterprise']
+
+  let selectedPlan = plans[0];
+</script>
+
+<RadioGroup value={selectedPlan} on:change={(e) => (selectedPlan = e.detail)} name="plan">
+  <RadioGroupLabel>Plan</RadioGroupLabel>
+  {#each plans as plan}
+    <RadioGroupOption value={plan} let:checked>
+      <span>{plan}</span>
+    </RadioGroupOption>
+  {/each}  
+</RadioGroup>
+```
+
+This lets you use a radio group inside a native HTML `<form>` and make traditional form submissions as if your radio group was a native HTML form control.
+
+Basic values like strings will be rendered as a single hidden input containing that value, but complex values like objects will be encoded into multiple inputs using a square bracket notation for the names.
+
+```svelte
+<input type="hidden" name="plan" value="startup" />
+```
+
 ## Accessibility notes
 
 ### Mouse interaction
@@ -184,6 +220,7 @@ The main Radio Group component.
 | `as`       | `div`   | `string`           | The element the `RadioGroup` should render as                            |
 | `disabled` | `false` | `boolean`          | Whether the `RadioGroup` and all of its `RadioGroupOption`s are disabled |
 | `value`    | --      | `T` \| `undefined` | The currently selected value in the `RadioGroup`                         |
+| `name`     | --      | `string`           | The name used when using this component inside a form.                   |
 
 This component also dispatches a custom event, which is listened to using the Svelte `on:` directive:
 

--- a/src/routes/docs/switch.svx
+++ b/src/routes/docs/switch.svx
@@ -244,6 +244,58 @@ Because switches are always rendered to the DOM (rather than being mounted/unmou
 </style>
 ```
 
+## Using with HTML forms
+
+If you add the `name` prop to your switch, a hidden `input` element will be rendered and kept in sync with the switch state.
+
+```svelte
+<script>
+  import {
+    Switch,
+    SwitchLabel,
+    SwitchGroup,
+  } from "@rgossiaux/svelte-headlessui";
+
+  let enabled = false;
+</script>
+
+<Switch checked={enabled} on:change={(e) => (enabled = e.detail)} name="notifications">  
+    <!-- ... -->
+</Switch>
+```
+
+This lets you use a radio group inside a native HTML `<form>` and make traditional form submissions as if your radio group was a native HTML form control.
+
+By default, the value will be `'on'` when the switch is checked, and not present when the switch is unchecked.
+
+```svelte
+<input type="hidden" name="notifications" value="on" />
+```
+
+You can customize the value if needed by using the value prop:
+
+```svelte
+<script>
+  import {
+    Switch,
+    SwitchLabel,
+    SwitchGroup,
+  } from "@rgossiaux/svelte-headlessui";
+
+  let enabled = false;
+</script>
+
+<Switch checked={enabled} on:change={(e) => (enabled = e.detail)} name="terms" value="accept">  
+    <!-- ... -->
+</Switch>
+```
+
+The hidden input will then use your custom value when the switch is checked:
+
+```svelte
+<input type="hidden" name="terms" value="accept" />
+```
+
 ## Accessibility notes
 
 ### Labels
@@ -274,10 +326,13 @@ For a full reference on all accessibility features implemented in `Switch`, see 
 
 The main switch component.
 
-| Prop      | Default  | Type      | Description                               |
-| --------- | -------- | --------- | ----------------------------------------- |
-| `as`      | `button` | `string`  | The element the `Switch` should render as |
-| `checked` | `false`  | `boolean` | Whether the switch is checked             |
+| Prop      | Default  | Type      | Description                                                               |
+| --------- | -------- | --------- | --------------------------------------------------------------------------|
+| `as`      | `button` | `string`  | The element the `Switch` should render as                                 |
+| `checked` | `false`  | `boolean` | Whether the switch is checked                                             |
+| `name`    | --       | `string`  | The name used when using this component inside a form.                    |
+| `value`   | --       | `string`  | The value used when using this component inside a form, if it is checked. |
+
 
 | Slot prop | Type      | Description                   |
 | --------- | --------- | ----------------------------- |


### PR DESCRIPTION
A port of the Combobox component from HeadlessUI
This follows the same implementation as the other components already here to keep it consistent
Added all the tests from the React version of the Comobobox and ported it to Svelte
Added a new documentation page following the style of the other components and used the text from the HeadlessUI version
There is still a few failing tests that need some investigation that I hope to have time to look at later this week.   

This branch is based of #121 since it also uses the new `<Hidden>` component so it can be used with forms.

Happy for any feedback