### PR TITLE
fix: update links to 2.0 docs

### DIFF
--- a/src/routes/docs/2.0/+page.svx
+++ b/src/routes/docs/2.0/+page.svx
@@ -14,6 +14,6 @@ These components can serve as the basis for your own components or design system
 
 The original Headless UI library was written by Tailwind Labs and is maintained by them. This project is a direct port, but it is not affiliated with Tailwind Labs and is neither endorsed by, nor supported by, them; it is a community port.
 
-Headless UI was written originally to support the paid component library called [Tailwind UI](https://tailwindui.com/). This port was done with this use case in mind, and you can [use this with Tailwind UI](docs/tailwind-ui).
+Headless UI was written originally to support the paid component library called [Tailwind UI](https://tailwindui.com/). This port was done with this use case in mind, and you can [use this with Tailwind UI](2.0/tailwind-ui).
 
-This library works very well with [Tailwind CSS](https://tailwindcss.com/) as a styling system, but it is not a requirement & there is nothing Tailwind-specific in the library. [See here](docs/general-concepts#component-styling) for different methods to style these components with Svelte.
+This library works very well with [Tailwind CSS](https://tailwindcss.com/) as a styling system, but it is not a requirement & there is nothing Tailwind-specific in the library. [See here](2.0/general-concepts#component-styling) for different methods to style these components with Svelte.


### PR DESCRIPTION
Looks like it's a duplicate of this https://github.com/rgossiaux/svelte-headlessui/pull/169, but should actually work

