### PR TITLE
Fix: <a/> links not working properly in <Dialog/>

### DIFF
--- a/src/lib/components/dialog/Dialog.svelte
+++ b/src/lib/components/dialog/Dialog.svelte
@@ -254,7 +254,13 @@
 
   function handleClick(e: CustomEvent) {
     let event = e as any as MouseEvent;
-    event.stopPropagation();
+    /* Can't stop propogation for <a/> elements
+    because they rely on a native Svelte event handler 
+    to work properly */
+    if (e.target.tagName != "A") {
+      event.stopPropagation();
+    }
+    
   }
 
   $: propsWeControl = {


### PR DESCRIPTION
This PR fixes an issue where clicking on an `<a/>` element that is inside a `<Dialog/>` caused a full page reload due to the fact that `<Dialog/>` had a click handler that called `e.stopPropogation()`. `<a/>` elements have a native Svelte event handler attached to them, which was being ignored due to `e.stopPropogation()`. This PR conditionally applies `e.stopPropogation()` *unless* the clicked element is not an `<a/>` element.