### PR TITLE
Fix: Tab key processed more than once in nested <Popover/>s

### DIFF
--- a/src/lib/components/popover/PopoverPanel.svelte
+++ b/src/lib/components/popover/PopoverPanel.svelte
@@ -93,6 +93,7 @@
     // but it will also "fix" some issues based on whether you are using a
     // Portal or not.
     event.preventDefault();
+    event.stopImmediatePropagation();
 
     let result = focusIn(
       $panelStore,


### PR DESCRIPTION
This PR fixes the issue where `handleWindowKeydown()` is called more than once in nested `<Popover>`, as each `<PopoverPanel>` has its own `<svelte:window>` with an `on:keydown` handler. The added `event.stopImmediatePropagation()` makes sure only one handler is called for the same keydown event.

This fixes #180.